### PR TITLE
Set retention-days value to 3 to remove GitHub Actions warning

### DIFF
--- a/.github/workflows/dockerized.yml
+++ b/.github/workflows/dockerized.yml
@@ -192,7 +192,7 @@ jobs:
         with:
           name: 'integration-test-logs'
           path: build/reports/tests/
-          retention-days: 5
+          retention-days: 3
 
       - name: 'Delete Test Clusters if Ungraceful Cancel'
         if: cancelled()


### PR DESCRIPTION
### Jira Ticket

RDS-856

### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete

### Summary

Set the retention value to 3 to match the docker configuration file.

### Description

- Set the retention value to 3 to match the docker configuration file.
- GitHub Actions warning should now be gone.

### Additional Reviewers

@yanw-bq @brunos-bq @justing-bq 
