### PR TITLE
RDS-927: Stub Monitor classes

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -53,12 +53,13 @@ WHILE(${DRIVER_INDEX} LESS ${DRIVERS_COUNT})
   SET(DRIVER_NAME "awsmysqlodbc${CONNECTOR_DRIVER_TYPE_SHORT}")
 
   SET(DRIVER_SRCS
-    base_metrics_holder.cc catalog.cc catalog_no_i_s.cc cluster_topology_info.cc 
-    cluster_aware_hit_metrics_holder.cc cluster_aware_metrics_container.cc 
-    cluster_aware_metrics.cc cluster_aware_time_metrics_holder.cc  
-    connect.cc connection.cc cursor.cc desc.cc dll.cc driver.cc 
-    error.cc execute.cc failover_connection_handler.cc failover_handler.cc 
+    base_metrics_holder.cc catalog.cc catalog_no_i_s.cc cluster_topology_info.cc
+    cluster_aware_hit_metrics_holder.cc cluster_aware_metrics_container.cc
+    cluster_aware_metrics.cc cluster_aware_time_metrics_holder.cc
+    connect.cc connection.cc cursor.cc desc.cc dll.cc driver.cc
+    error.cc execute.cc failover_connection_handler.cc failover_handler.cc
     failover_reader_handler.cc failover_writer_handler.cc handle.cc host_info.cc info.cc
+    monitor.cc monitor_connection_context.cc monitor_service.cc monitor_thread_container.cc
     my_prepared_stmt.cc my_stmt.cc mylog.cc options.cc parse.cc prepare.cc query_parsing.cc
     results.cc topology_service.cc transact.cc utility.cc)
 
@@ -77,9 +78,10 @@ WHILE(${DRIVER_INDEX} LESS ${DRIVERS_COUNT})
     CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/driver/driver.def.cmake ${CMAKE_SOURCE_DIR}/driver/driver${CONNECTOR_DRIVER_TYPE_SHORT}.def @ONLY)
     CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/driver/driver.rc.cmake ${CMAKE_SOURCE_DIR}/driver/driver${CONNECTOR_DRIVER_TYPE_SHORT}.rc @ONLY)
     SET(DRIVER_SRCS ${DRIVER_SRCS} driver${CONNECTOR_DRIVER_TYPE_SHORT}.def driver${CONNECTOR_DRIVER_TYPE_SHORT}.rc  
-                                   base_metrics_holder.h catalog.h cluster_aware_hit_metrics_holder.h cluster_aware_metrics_container.h 
-                                   cluster_aware_metrics.h cluster_aware_time_metrics_holder.h cluster_topology_info.h connection.h 
-                                   driver.h error.h failover.h host_info.h mylog.h myutil.h parse.h query_parsing.h topology_service.h
+                                   base_metrics_holder.h catalog.h cluster_aware_hit_metrics_holder.h cluster_aware_metrics_container.h
+                                   cluster_aware_metrics.h cluster_aware_time_metrics_holder.h cluster_topology_info.h connection.h
+                                   driver.h error.h failover.h host_info.h monitor.h monitor_connection_context.h monitor_service.h
+                                   monitor_thread_container.h mylog.h myutil.h parse.h query_parsing.h topology_service.h
                                    ../MYODBC_MYSQL.h ../MYODBC_CONF.h ../MYODBC_ODBC.h)
   ENDIF(WIN32)
 

--- a/driver/monitor.cc
+++ b/driver/monitor.cc
@@ -1,0 +1,54 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "monitor.h"
+
+MONITOR::MONITOR(std::shared_ptr<HOST_INFO> host_info, long monitor_disposal_time) {
+    this->host = host_info;
+    this->disposal_time = monitor_disposal_time;
+}
+
+void MONITOR::start_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context) {
+    // TODO: Implement
+}
+
+void MONITOR::stop_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context) {
+    // TODO: Implement
+}
+
+bool MONITOR::is_stopped() {
+    // TODO: Implement
+    return false;
+}
+
+void MONITOR::clear_contexts() {
+    // TODO: Implement
+}
+
+CONNECTION_STATUS MONITOR::check_connection_status(int shortest_detection_interval) {
+    // TODO: Implement
+    return CONNECTION_STATUS{ false, 0 };
+}

--- a/driver/monitor.h
+++ b/driver/monitor.h
@@ -1,0 +1,57 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef __MONITOR_H__
+#define __MONITOR_H__
+
+#include "host_info.h"
+#include "monitor_connection_context.h"
+
+#include <queue>
+
+struct CONNECTION_STATUS {
+    bool is_valid;
+    long elapsed_time;
+};
+
+class MONITOR {
+public:
+    MONITOR(std::shared_ptr<HOST_INFO> host, long disposal_time);
+
+    void start_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
+    void stop_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
+    bool is_stopped();
+    void clear_contexts();
+
+private:
+    std::shared_ptr<HOST_INFO> host;
+    long disposal_time;
+    std::queue<std::shared_ptr<MONITOR_CONNECTION_CONTEXT>> contexts;
+
+    CONNECTION_STATUS check_connection_status(int shortest_detection_interval);
+};
+
+#endif /* __MONITOR_H__ */

--- a/driver/monitor_connection_context.cc
+++ b/driver/monitor_connection_context.cc
@@ -1,0 +1,29 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "monitor_connection_context.h"
+
+// TODO: Implement

--- a/driver/monitor_connection_context.h
+++ b/driver/monitor_connection_context.h
@@ -1,0 +1,34 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef __MONITORCONNECTIONCONTEXT_H__
+#define __MONITORCONNECTIONCONTEXT_H__
+
+class MONITOR_CONNECTION_CONTEXT {
+    // TODO: Implement
+};
+
+#endif /* __MONITORCONNECTIONCONTEXT_H__ */

--- a/driver/monitor_service.cc
+++ b/driver/monitor_service.cc
@@ -1,0 +1,63 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "monitor_service.h"
+
+MONITOR_SERVICE::MONITOR_SERVICE() {
+    // TODO: Implement
+}
+
+void MONITOR_SERVICE::start_monitoring(
+    DBC* dbc,
+    std::set<std::string> node_keys,
+    std::shared_ptr<HOST_INFO> host,
+    int failure_detection_time,
+    int failure_detection_interval,
+    int failure_detection_count) {
+
+    // TODO: Implement
+}
+
+void MONITOR_SERVICE::stop_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context) {
+    // TODO: Implement
+}
+
+void MONITOR_SERVICE::stop_monitoring_for_all_connections(std::set<std::string> node_keys) {
+    // TODO: Implement
+}
+
+void MONITOR_SERVICE::notify_unused(std::shared_ptr<MONITOR> monitor) {
+    // TODO: Implement
+}
+
+void MONITOR_SERVICE::release_resources() {
+    // TODO: Implement
+}
+
+std::shared_ptr<MONITOR> MONITOR_SERVICE::get_monitor(std::set<std::string> node_keys, std::shared_ptr<HOST_INFO> host) {
+    // TODO: Implement
+    return nullptr;
+}

--- a/driver/monitor_service.h
+++ b/driver/monitor_service.h
@@ -1,0 +1,55 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef __MONITORSERVICE_H__
+#define __MONITORSERVICE_H__
+
+#include "driver.h"
+#include "monitor_thread_container.h"
+
+class MONITOR_SERVICE {
+public:
+    MONITOR_SERVICE();
+
+    void start_monitoring(
+        DBC* dbc,
+        std::set<std::string> node_keys,
+        std::shared_ptr<HOST_INFO> host,
+        int failure_detection_time,
+        int failure_detection_interval,
+        int failure_detection_count);
+    void stop_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
+    void stop_monitoring_for_all_connections(std::set<std::string> node_keys);
+    void notify_unused(std::shared_ptr<MONITOR> monitor);
+    void release_resources();
+
+private:
+    MONITOR_THREAD_CONTAINER thread_container;
+
+    std::shared_ptr<MONITOR> get_monitor(std::set<std::string> node_keys, std::shared_ptr<HOST_INFO> host);
+};
+
+#endif /* __MONITORSERVICE_H__ */

--- a/driver/monitor_thread_container.cc
+++ b/driver/monitor_thread_container.cc
@@ -1,0 +1,50 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "monitor_thread_container.h"
+
+std::string MONITOR_THREAD_CONTAINER::get_node(std::set<std::string> node_keys) {
+    // TODO: Implement
+    return "";
+}
+
+std::shared_ptr<MONITOR> MONITOR_THREAD_CONTAINER::get_monitor(std::string node) {
+    // TODO: Implement
+    return nullptr;
+}
+
+std::shared_ptr<MONITOR> MONITOR_THREAD_CONTAINER::get_or_create_monitor(std::set<std::string> node_keys) {
+    // TODO: Implement
+    return nullptr;
+}
+
+void MONITOR_THREAD_CONTAINER::reset_resource(std::shared_ptr<MONITOR> monitor) {
+    // TODO: Implement
+}
+
+void MONITOR_THREAD_CONTAINER::release_resource(std::shared_ptr<MONITOR> monitor) {
+    // TODO: Implement
+}

--- a/driver/monitor_thread_container.h
+++ b/driver/monitor_thread_container.h
@@ -1,0 +1,50 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef __MONITORTHREADCONTAINER_H__
+#define __MONITORTHREADCONTAINER_H__
+
+#include "monitor.h"
+
+#include <future>
+#include <map>
+#include <set>
+
+class MONITOR_THREAD_CONTAINER {
+public:
+    std::string get_node(std::set<std::string> node_keys);
+    std::shared_ptr<MONITOR> get_monitor(std::string node);
+    std::shared_ptr<MONITOR> get_or_create_monitor(std::set<std::string> node_keys);
+    void reset_resource(std::shared_ptr<MONITOR> monitor);
+    void release_resource(std::shared_ptr<MONITOR> monitor);
+
+private:
+    std::map<std::string, std::shared_ptr<MONITOR>> monitor_map;
+    std::map<std::shared_ptr<MONITOR>, std::future<void>> task_map;
+    std::queue<std::shared_ptr<MONITOR>> available_monitors;
+};
+
+#endif /* __MONITORTHREADCONTAINER_H__ */


### PR DESCRIPTION
### Jira Ticket

[RDS-927]

### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete

### Summary

Stub out `MONITOR`, `MONITOR_SERVICE`, `MONITOR_THREAD_CONTAINER` classes.

### Description

Stub out `MONITOR`, `MONITOR_SERVICE`, `MONITOR_THREAD_CONTAINER` classes. Also created empty `MONITOR_CONNECTION_CONTEXT` class (to be stubbed/implemented later).
