### PR TITLE
Use of a mutex to execute abort_connection atomically

### DIFF
--- a/driver/monitor.cc
+++ b/driver/monitor.cc
@@ -26,7 +26,7 @@
 
 #include "monitor.h"
 
-MONITOR::MONITOR(std::shared_ptr<HOST_INFO> host_info, long monitor_disposal_time) {
+MONITOR::MONITOR(std::shared_ptr<HOST_INFO> host_info, std::chrono::milliseconds monitor_disposal_time) {
     this->host = host_info;
     this->disposal_time = monitor_disposal_time;
 }
@@ -50,5 +50,5 @@ void MONITOR::clear_contexts() {
 
 CONNECTION_STATUS MONITOR::check_connection_status(int shortest_detection_interval) {
     // TODO: Implement
-    return CONNECTION_STATUS{ false, 0 };
+    return CONNECTION_STATUS{ false, std::chrono::milliseconds(0) };
 }

--- a/driver/monitor.h
+++ b/driver/monitor.h
@@ -34,12 +34,12 @@
 
 struct CONNECTION_STATUS {
     bool is_valid;
-    long elapsed_time;
+    std::chrono::milliseconds elapsed_time;
 };
 
 class MONITOR {
 public:
-    MONITOR(std::shared_ptr<HOST_INFO> host, long disposal_time);
+    MONITOR(std::shared_ptr<HOST_INFO> host, std::chrono::milliseconds disposal_time);
 
     void start_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
     void stop_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
@@ -48,7 +48,8 @@ public:
 
 private:
     std::shared_ptr<HOST_INFO> host;
-    long disposal_time;
+    std::chrono::milliseconds connection_check_interval = std::chrono::milliseconds(INT_MAX);
+    std::chrono::milliseconds disposal_time;
     std::queue<std::shared_ptr<MONITOR_CONNECTION_CONTEXT>> contexts;
 
     CONNECTION_STATUS check_connection_status(int shortest_detection_interval);

--- a/driver/monitor_connection_context.cc
+++ b/driver/monitor_connection_context.cc
@@ -27,24 +27,25 @@
 #include "monitor_connection_context.h"
 
 #include <algorithm>
+#include <mutex>
 
 MONITOR_CONNECTION_CONTEXT::MONITOR_CONNECTION_CONTEXT(DBC* connection_to_abort,
     std::set<std::string> node_keys,
-    int failure_detection_interval_ms,
-    int failure_detection_time_ms,
+    std::chrono::milliseconds failure_detection_time,
+    std::chrono::milliseconds failure_detection_interval,
     int failure_detection_count) : connection_to_abort{connection_to_abort},
                                    node_keys{node_keys},
-                                   failure_detection_interval_ms{failure_detection_interval_ms},
-                                   failure_detection_time_ms{failure_detection_time_ms},
+                                   failure_detection_time{failure_detection_time},
+                                   failure_detection_interval{failure_detection_interval},
                                    failure_detection_count{failure_detection_count} {}
 
 MONITOR_CONNECTION_CONTEXT::~MONITOR_CONNECTION_CONTEXT() {}
 
-long MONITOR_CONNECTION_CONTEXT::get_start_monitor_time() {
+std::chrono::steady_clock::time_point MONITOR_CONNECTION_CONTEXT::get_start_monitor_time() {
     return start_monitor_time;
 }
 
-void MONITOR_CONNECTION_CONTEXT::set_start_monitor_time(long time) {
+void MONITOR_CONNECTION_CONTEXT::set_start_monitor_time(std::chrono::steady_clock::time_point time) {
     start_monitor_time = time;
 }
 
@@ -52,12 +53,12 @@ std::set<std::string> MONITOR_CONNECTION_CONTEXT::get_node_keys() {
     return node_keys;
 }
 
-int MONITOR_CONNECTION_CONTEXT::get_failure_detection_time_ms() {
-    return failure_detection_time_ms;
+std::chrono::milliseconds MONITOR_CONNECTION_CONTEXT::get_failure_detection_time() {
+    return failure_detection_time;
 }
 
-int MONITOR_CONNECTION_CONTEXT::get_failure_detection_interval_ms() {
-    return failure_detection_interval_ms;
+std::chrono::milliseconds MONITOR_CONNECTION_CONTEXT::get_failure_detection_interval() {
+    return failure_detection_interval;
 }
 
 int MONITOR_CONNECTION_CONTEXT::get_failure_detection_count() {
@@ -76,19 +77,19 @@ void MONITOR_CONNECTION_CONTEXT::increment_failure_count() {
     failure_count++;
 }
 
-void MONITOR_CONNECTION_CONTEXT::set_invalid_node_start_time(long time_ms) {
-    invalid_node_start_time = time_ms;
+void MONITOR_CONNECTION_CONTEXT::set_invalid_node_start_time(std::chrono::steady_clock::time_point time) {
+    invalid_node_start_time = time;
 }
 
 void MONITOR_CONNECTION_CONTEXT::reset_invalid_node_start_time() {
-    invalid_node_start_time = 0;
+    invalid_node_start_time = std::chrono::steady_clock::time_point();
 }
 
 bool MONITOR_CONNECTION_CONTEXT::is_invalid_node_start_time_defined() {
-    return invalid_node_start_time > 0;
+    return invalid_node_start_time > std::chrono::steady_clock::time_point();
 }
 
-long MONITOR_CONNECTION_CONTEXT::get_invalid_node_start_time() {
+std::chrono::steady_clock::time_point MONITOR_CONNECTION_CONTEXT::get_invalid_node_start_time() {
     return invalid_node_start_time;
 }
 
@@ -112,34 +113,32 @@ DBC* MONITOR_CONNECTION_CONTEXT::get_connection_to_abort() {
     return connection_to_abort;
 }
 
-// TODO synchronized
-void MONITOR_CONNECTION_CONTEXT::abort_connection() {
-    if ((get_connection_to_abort()) || (!is_active_context())) {
-        return;
-    }
-
-    // TODO Equivalent of: this.connectionToAbort.abortInternal();
-}
-
 // Update whether the connection is still valid if the total elapsed time has passed the grace period.
-void MONITOR_CONNECTION_CONTEXT::update_connection_status(long status_check_start_time,
-                                                        long current_time,
-                                                        bool is_valid) {
+void MONITOR_CONNECTION_CONTEXT::update_connection_status(
+    std::chrono::steady_clock::time_point status_check_start_time,
+    std::chrono::steady_clock::time_point current_time,
+    bool is_valid) {
+    
     if (!is_active_context()) {
       return;
     }
 
-    const long total_elapsed_time_ms = current_time - get_start_monitor_time();
+    auto total_elapsed_time = current_time - get_start_monitor_time();
 
-    if (total_elapsed_time_ms > get_failure_detection_time_ms()) {
+    if (total_elapsed_time > get_failure_detection_time()) {
       set_connection_valid(is_valid, status_check_start_time, current_time);
     }
 }
 
 // Set whether the connection to the server is still valid based on the monitoring settings.
-void MONITOR_CONNECTION_CONTEXT::set_connection_valid(bool connection_valid,
-                                                      long status_check_start_time,
-                                                      long current_time) {
+void MONITOR_CONNECTION_CONTEXT::set_connection_valid(
+    bool connection_valid,
+    std::chrono::steady_clock::time_point status_check_start_time,
+    std::chrono::steady_clock::time_point current_time) {
+
+    FILE* log_file = connection_to_abort->log_file.get();
+    unsigned long dbc_id = connection_to_abort->id;
+
     if (!connection_valid) {
         increment_failure_count();
 
@@ -147,22 +146,30 @@ void MONITOR_CONNECTION_CONTEXT::set_connection_valid(bool connection_valid,
             set_invalid_node_start_time(status_check_start_time);
         }
 
-        const long invalid_node_duration_ms = current_time - get_invalid_node_start_time();
-        const long max_invalid_node_duration_ms = get_failure_detection_interval_ms() * (std::max)(0, get_failure_detection_count());
+        auto invalid_node_duration = current_time - get_invalid_node_start_time();
+        auto max_invalid_node_duration = get_failure_detection_interval() * (std::max)(0, get_failure_detection_count());
 
-        if (invalid_node_duration_ms >= max_invalid_node_duration_ms) {
-            // TODO MYLOG_TRACE(log_file, 0, "[MONITOR_CONNECTION_CONTEXT] Node '%s' is *dead*.", node_keys);
+        if (invalid_node_duration >= max_invalid_node_duration) {
+            // TODO MYLOG_TRACE(log_file, dbc_id, "[MONITOR_CONNECTION_CONTEXT] Node '%s' is *dead*.", node_keys.begin());
             set_node_unhealthy(true);
             abort_connection();
             return;
         }
 
-        // TODO MYLOG_TRACE(log_file, 0, "[MONITOR_CONNECTION_CONTEXT] Node '%s' is *not responding* (%d).", node_keys, get_failure_count());
+        // TODO MYLOG_TRACE(log_file, dbc_id, "[MONITOR_CONNECTION_CONTEXT] Node '%s' is *not responding* (%d).", node_keys.begin(), get_failure_count());
         return;
     }
 
     set_failure_count(0);
     reset_invalid_node_start_time();
     set_node_unhealthy(false);
-    // TODO MYLOG_TRACE(log_file, 0, "[MONITOR_CONNECTION_CONTEXT] Node '%s' is *alive*.", node_keys);
+    // TODO MYLOG_TRACE(log_file, dbc_id, "[MONITOR_CONNECTION_CONTEXT] Node '%s' is *alive*.", node_keys.begin());
+}
+
+void MONITOR_CONNECTION_CONTEXT::abort_connection() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if ((get_connection_to_abort()) || (!is_active_context())) {
+        return;
+    }
+    connection_to_abort->close();
 }

--- a/driver/monitor_connection_context.h
+++ b/driver/monitor_connection_context.h
@@ -27,8 +27,7 @@
 #ifndef __MONITORCONNECTIONCONTEXT_H__
 #define __MONITORCONNECTIONCONTEXT_H__
 
-#include "failover.h"
-#include "mylog.h"
+#include "driver.h"
 
 #include <set>
 
@@ -38,44 +37,52 @@ class MONITOR_CONNECTION_CONTEXT {
 public:
     MONITOR_CONNECTION_CONTEXT(DBC* connection_to_abort,
                                std::set<std::string> node_keys,
-                               int failure_detection_interval_ms,
-                               int failure_detection_time_ms,
+                               std::chrono::milliseconds failure_detection_time,
+                               std::chrono::milliseconds failure_detection_interval,
                                int failure_detection_count);
     ~MONITOR_CONNECTION_CONTEXT();
 
-    long get_start_monitor_time();
-    void set_start_monitor_time(long time);
+    std::chrono::steady_clock::time_point get_start_monitor_time();
+    void set_start_monitor_time(std::chrono::steady_clock::time_point time);
     std::set<std::string> get_node_keys();
-    int get_failure_detection_time_ms();
-    int get_failure_detection_interval_ms();
+    std::chrono::milliseconds get_failure_detection_time();
+    std::chrono::milliseconds get_failure_detection_interval();
     int get_failure_detection_count();
     int get_failure_count();
     void set_failure_count(int count);
     void increment_failure_count();
-    void set_invalid_node_start_time(long time_ms);
+    void set_invalid_node_start_time(std::chrono::steady_clock::time_point time);
     void reset_invalid_node_start_time();
     bool is_invalid_node_start_time_defined();
-    long get_invalid_node_start_time();
+    std::chrono::steady_clock::time_point get_invalid_node_start_time();
     bool is_node_unhealthy();
     void set_node_unhealthy(bool node);
     bool is_active_context();
     void invalidate();
     DBC* get_connection_to_abort();
 
-    void update_connection_status(long status_check_start_time, long current_time, bool is_valid);
-    void set_connection_valid(bool connection_valid, long status_check_start_time, long current_time);
+    void update_connection_status(
+        std::chrono::steady_clock::time_point status_check_start_time,
+        std::chrono::steady_clock::time_point current_time,
+        bool is_valid);
+    void set_connection_valid(
+        bool connection_valid,
+        std::chrono::steady_clock::time_point status_check_start_time,
+        std::chrono::steady_clock::time_point current_time);
     void abort_connection();
 
 private:
-    int failure_detection_interval_ms;
-    int failure_detection_time_ms;
+    std::mutex mutex_;
+    
+    std::chrono::milliseconds failure_detection_time;
+    std::chrono::milliseconds failure_detection_interval;
     int failure_detection_count;
 
     std::set<std::string> node_keys;
     DBC* connection_to_abort;
 
-    long start_monitor_time;
-    long invalid_node_start_time;
+    std::chrono::steady_clock::time_point start_monitor_time;
+    std::chrono::steady_clock::time_point invalid_node_start_time;
     int failure_count;
     bool node_unhealthy;
     bool active_context = true;

--- a/driver/monitor_service.cc
+++ b/driver/monitor_service.cc
@@ -34,9 +34,10 @@ void MONITOR_SERVICE::start_monitoring(
     DBC* dbc,
     std::set<std::string> node_keys,
     std::shared_ptr<HOST_INFO> host,
-    int failure_detection_time,
-    int failure_detection_interval,
-    int failure_detection_count) {
+    std::chrono::milliseconds failure_detection_time,
+    std::chrono::milliseconds failure_detection_interval,
+    int failure_detection_count,
+    std::chrono::milliseconds disposal_time) {
 
     // TODO: Implement
 }

--- a/driver/monitor_service.h
+++ b/driver/monitor_service.h
@@ -38,9 +38,10 @@ public:
         DBC* dbc,
         std::set<std::string> node_keys,
         std::shared_ptr<HOST_INFO> host,
-        int failure_detection_time,
-        int failure_detection_interval,
-        int failure_detection_count);
+        std::chrono::milliseconds failure_detection_time,
+        std::chrono::milliseconds failure_detection_interval,
+        int failure_detection_count,
+        std::chrono::milliseconds disposal_time);
     void stop_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
     void stop_monitoring_for_all_connections(std::set<std::string> node_keys);
     void notify_unused(std::shared_ptr<MONITOR> monitor);

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(
   failover_handler_test.cc
   failover_reader_handler_test.cc
   failover_writer_handler_test.cc
+  monitor_connection_context_test.cc
   query_parsing_test.cc
   main.cc
   topology_service_test.cc

--- a/testing/monitor_connection_context_test.cc
+++ b/testing/monitor_connection_context_test.cc
@@ -1,0 +1,83 @@
+/*
+ * AWS ODBC Driver for MySQL
+ * Copyright Amazon.com Inc. or affiliates.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "driver/monitor_connection_context.h"
+
+#include "mock_objects.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using ::testing::_;
+using ::testing::Return;
+
+#define FAILURE_DETECTION_TIME_MS 10
+#define FAILURE_DETECTION_INTERVAL_MS 100
+#define FAILURE_DETECTION_COUNT 3
+#define VALIDATION_INTERVAL_MILLIS 50
+
+namespace {
+    std::set<std::string> node_keys = { "any.node.domain" };
+}
+
+class MonitorConnectionContextTest : public testing::Test {
+ protected:
+    MONITOR_CONNECTION_CONTEXT* context;
+
+    static void SetUpTestSuite() {}
+
+    static void TearDownTestSuite() {}
+
+    void SetUp() override {
+        context = new MONITOR_CONNECTION_CONTEXT(NULL,
+                                                 node_keys,
+                                                 FAILURE_DETECTION_INTERVAL_MS,
+                                                 FAILURE_DETECTION_TIME_MS,
+                                                 FAILURE_DETECTION_COUNT);
+    }
+
+    void TearDown() override {
+        delete context;
+    }
+};
+
+TEST_F(MonitorConnectionContextTest, IsNodeUnhealthyWithConnection_ReturnFalse) {
+    //auto now = std::chrono::system_clock::now();
+    //std::chrono::duration<long> current_time_ms = std::chrono::milliseconds(now).count();
+    context->set_connection_valid(true, 1234, 1234);
+    EXPECT_FALSE(context->is_node_unhealthy());
+    EXPECT_EQ(0, context->get_failure_count());
+}
+
+TEST_F(MonitorConnectionContextTest, IsNodeUnhealthyWithInvalidConnection_ReturnFalse) {
+    //auto now = std::chrono::system_clock::now();
+    //std::chrono::duration<long> current_time_ms = std::chrono::milliseconds(now).count();
+    context->set_connection_valid(false, 1234, 1234);
+    EXPECT_FALSE(context->is_node_unhealthy());
+    EXPECT_EQ(1, context->get_failure_count());
+}


### PR DESCRIPTION
### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [ ] This is complete

### Summary

Use of a mutex to execute abort_connection atomically

### Additional Reviewers

@justing-bq 
@yanw-bq 
@sergiyvamz 
