### PR TITLE
Rework time types for Monitor classes

### DIFF
--- a/driver/monitor.cc
+++ b/driver/monitor.cc
@@ -26,7 +26,7 @@
 
 #include "monitor.h"
 
-MONITOR::MONITOR(std::shared_ptr<HOST_INFO> host_info, long monitor_disposal_time) {
+MONITOR::MONITOR(std::shared_ptr<HOST_INFO> host_info, std::chrono::milliseconds monitor_disposal_time) {
     this->host = host_info;
     this->disposal_time = monitor_disposal_time;
 }
@@ -50,5 +50,5 @@ void MONITOR::clear_contexts() {
 
 CONNECTION_STATUS MONITOR::check_connection_status(int shortest_detection_interval) {
     // TODO: Implement
-    return CONNECTION_STATUS{ false, 0 };
+    return CONNECTION_STATUS{ false, std::chrono::milliseconds(0) };
 }

--- a/driver/monitor.h
+++ b/driver/monitor.h
@@ -34,12 +34,12 @@
 
 struct CONNECTION_STATUS {
     bool is_valid;
-    long elapsed_time;
+    std::chrono::milliseconds elapsed_time;
 };
 
 class MONITOR {
 public:
-    MONITOR(std::shared_ptr<HOST_INFO> host, long disposal_time);
+    MONITOR(std::shared_ptr<HOST_INFO> host, std::chrono::milliseconds disposal_time);
 
     void start_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
     void stop_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
@@ -48,7 +48,8 @@ public:
 
 private:
     std::shared_ptr<HOST_INFO> host;
-    long disposal_time;
+    std::chrono::milliseconds connection_check_interval = std::chrono::milliseconds(INT_MAX);
+    std::chrono::milliseconds disposal_time;
     std::queue<std::shared_ptr<MONITOR_CONNECTION_CONTEXT>> contexts;
 
     CONNECTION_STATUS check_connection_status(int shortest_detection_interval);

--- a/driver/monitor_connection_context.h
+++ b/driver/monitor_connection_context.h
@@ -38,44 +38,50 @@ class MONITOR_CONNECTION_CONTEXT {
 public:
     MONITOR_CONNECTION_CONTEXT(DBC* connection_to_abort,
                                std::set<std::string> node_keys,
-                               int failure_detection_interval_ms,
-                               int failure_detection_time_ms,
+                               std::chrono::milliseconds failure_detection_time,
+                               std::chrono::milliseconds failure_detection_interval,
                                int failure_detection_count);
     ~MONITOR_CONNECTION_CONTEXT();
 
-    long get_start_monitor_time();
-    void set_start_monitor_time(long time);
+    std::chrono::steady_clock::time_point get_start_monitor_time();
+    void set_start_monitor_time(std::chrono::steady_clock::time_point time);
     std::set<std::string> get_node_keys();
-    int get_failure_detection_time_ms();
-    int get_failure_detection_interval_ms();
+    std::chrono::milliseconds get_failure_detection_time();
+    std::chrono::milliseconds get_failure_detection_interval();
     int get_failure_detection_count();
     int get_failure_count();
     void set_failure_count(int count);
     void increment_failure_count();
-    void set_invalid_node_start_time(long time_ms);
+    void set_invalid_node_start_time(std::chrono::steady_clock::time_point time);
     void reset_invalid_node_start_time();
     bool is_invalid_node_start_time_defined();
-    long get_invalid_node_start_time();
+    std::chrono::steady_clock::time_point get_invalid_node_start_time();
     bool is_node_unhealthy();
     void set_node_unhealthy(bool node);
     bool is_active_context();
     void invalidate();
     DBC* get_connection_to_abort();
 
-    void update_connection_status(long status_check_start_time, long current_time, bool is_valid);
-    void set_connection_valid(bool connection_valid, long status_check_start_time, long current_time);
+    void update_connection_status(
+        std::chrono::steady_clock::time_point status_check_start_time,
+        std::chrono::steady_clock::time_point current_time,
+        bool is_valid);
+    void set_connection_valid(
+        bool connection_valid,
+        std::chrono::steady_clock::time_point status_check_start_time,
+        std::chrono::steady_clock::time_point current_time);
     void abort_connection();
 
 private:
-    int failure_detection_interval_ms;
-    int failure_detection_time_ms;
+    std::chrono::milliseconds failure_detection_time;
+    std::chrono::milliseconds failure_detection_interval;
     int failure_detection_count;
 
     std::set<std::string> node_keys;
     DBC* connection_to_abort;
 
-    long start_monitor_time;
-    long invalid_node_start_time;
+    std::chrono::steady_clock::time_point start_monitor_time;
+    std::chrono::steady_clock::time_point invalid_node_start_time;
     int failure_count;
     bool node_unhealthy;
     bool active_context = true;

--- a/driver/monitor_service.cc
+++ b/driver/monitor_service.cc
@@ -34,9 +34,10 @@ void MONITOR_SERVICE::start_monitoring(
     DBC* dbc,
     std::set<std::string> node_keys,
     std::shared_ptr<HOST_INFO> host,
-    int failure_detection_time,
-    int failure_detection_interval,
-    int failure_detection_count) {
+    std::chrono::milliseconds failure_detection_time,
+    std::chrono::milliseconds failure_detection_interval,
+    int failure_detection_count,
+    std::chrono::milliseconds disposal_time) {
 
     // TODO: Implement
 }

--- a/driver/monitor_service.h
+++ b/driver/monitor_service.h
@@ -38,9 +38,10 @@ public:
         DBC* dbc,
         std::set<std::string> node_keys,
         std::shared_ptr<HOST_INFO> host,
-        int failure_detection_time,
-        int failure_detection_interval,
-        int failure_detection_count);
+        std::chrono::milliseconds failure_detection_time,
+        std::chrono::milliseconds failure_detection_interval,
+        int failure_detection_count,
+        std::chrono::milliseconds disposal_time);
     void stop_monitoring(std::shared_ptr<MONITOR_CONNECTION_CONTEXT> context);
     void stop_monitoring_for_all_connections(std::set<std::string> node_keys);
     void notify_unused(std::shared_ptr<MONITOR> monitor);


### PR DESCRIPTION
### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [ ] This is complete

### Summary

Use chrono::stead_clock::time_point for time values and chrono::milliseconds for durations instead of int/long.