### PR TITLE
Archiving EFM performance tests results in Github actions.

### DIFF
--- a/.github/workflows/dockerized.yml
+++ b/.github/workflows/dockerized.yml
@@ -186,6 +186,12 @@ jobs:
           if [[ -f failover_performance.xlsx && -s failover_performance.xlsx ]]; then
             cp failover_performance.xlsx ./reports/tests/failover_performance.xlsx
           fi
+          if [[ -f efm_performance.xlsx && -s efm_performance.xlsx ]]; then
+            cp efm_performance.xlsx ./reports/tests/efm_performance.xlsx
+          fi
+          if [[ -f efm_detection_performance.xlsx && -s efm_detection_performance.xlsx ]]; then
+            cp efm_detection_performance.xlsx ./reports/tests/efm_detection_performance.xlsx
+          fi
 
       - name: 'Archive log results'
         if: always()


### PR DESCRIPTION
### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete

### Summary

This PR moves the xlsx files with the EFM performance tests results to a folder that will be archived and made available to download after the run.

### Additional Reviewers

@sergiyvamz 
@yanw-bq 
@justing-bq 
