### PR TITLE
Use UNIT_TEST_BUILD macro for friend class TEST_UTILS statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 #-----------------------------------------------------
 
 IF(ENABLE_UNIT_TESTS)
-  ADD_DEFINITIONS(-DUNIT_TESTING)
+  ADD_DEFINITIONS(-DUNIT_TEST_BUILD)
 ENDIF(ENABLE_UNIT_TESTS)
 
 #-----------------------------------------------------

--- a/driver/monitor.h
+++ b/driver/monitor.h
@@ -84,7 +84,7 @@ private:
     std::chrono::milliseconds find_shortest_interval();
     virtual std::chrono::steady_clock::time_point get_current_time();
 
-#ifdef UNIT_TESTING
+#ifdef UNIT_TEST_BUILD
     // Allows for testing private methods
     friend class TEST_UTILS;
 #endif

--- a/driver/monitor_thread_container.h
+++ b/driver/monitor_thread_container.h
@@ -78,7 +78,7 @@ protected:
     ctpl::thread_pool thread_pool;
     std::mutex mutex_;
 
-#ifdef UNIT_TESTING
+#ifdef UNIT_TEST_BUILD
     // Allows for testing private methods
     friend class TEST_UTILS;
 #endif


### PR DESCRIPTION
### Jira Ticket

[RDS-1062]

### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [ ] This is ready for review
- [x] This is complete

### Summary

Use `UNIT_TEST_BUILD` macro for `friend class TEST_UTILS` statements.

### Description

We have a `TEST_UTILS` class so our unit tests can have access to private members for any class that is a friend class with `TEST_UTILS`. However we do not want the friend class statements to be part of the actual driver build. Wrapping the friend class statements with `#ifdef UNIT_TEST_BUILD` allows us to only build those statements during the unit test build rather than the actual driver build.