### PR TITLE
Increase sleep time for PopulateAndRemoveMappings test

### DIFF
--- a/testing/monitor_thread_container_test.cc
+++ b/testing/monitor_thread_container_test.cc
@@ -257,7 +257,7 @@ TEST_F(MonitorThreadContainerTest, PopulateAndRemoveMappings) {
 
     monitor_service->stop_monitoring(context);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 
     EXPECT_FALSE(TEST_UTILS::has_monitor(thread_container, node_key));
     EXPECT_FALSE(TEST_UTILS::has_any_tasks(thread_container));


### PR DESCRIPTION
### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [ ] This is ready for review
- [x] This is complete

### Summary

Increase sleep time for `MonitorThreadContainerTest.PopulateAndRemoveMappings`.

### Description

This test sometimes fails because not enough time passes for the monitor/task maps to empty. Increasing the sleep time should make this test less flaky.
