### PR TITLE
Enable logger for MONITOR_CONNECTION_CONTEXT the same way as MONITOR

### DIFF
--- a/driver/monitor_connection_context.cc
+++ b/driver/monitor_connection_context.cc
@@ -34,14 +34,15 @@ MONITOR_CONNECTION_CONTEXT::MONITOR_CONNECTION_CONTEXT(DBC* connection_to_abort,
     std::set<std::string> node_keys,
     std::chrono::milliseconds failure_detection_time,
     std::chrono::milliseconds failure_detection_interval,
-    int failure_detection_count) : connection_to_abort{connection_to_abort},
+    int failure_detection_count,
+    bool enable_logging) : connection_to_abort{connection_to_abort},
                                    node_keys{node_keys},
                                    failure_detection_time{failure_detection_time},
                                    failure_detection_interval{failure_detection_interval},
                                    failure_detection_count{failure_detection_count},
                                    failure_count{0},
                                    node_unhealthy{false} {
-    if (connection_to_abort && connection_to_abort->ds && connection_to_abort->ds->save_queries)
+    if (enable_logging)
         this->logger = init_log_file();
 }
 

--- a/driver/monitor_connection_context.h
+++ b/driver/monitor_connection_context.h
@@ -44,7 +44,8 @@ public:
                                std::set<std::string> node_keys,
                                std::chrono::milliseconds failure_detection_time,
                                std::chrono::milliseconds failure_detection_interval,
-                               int failure_detection_count);
+                               int failure_detection_count,
+                               bool enable_logging = false);
     virtual ~MONITOR_CONNECTION_CONTEXT();
 
     std::chrono::steady_clock::time_point get_start_monitor_time();

--- a/driver/monitor_service.cc
+++ b/driver/monitor_service.cc
@@ -58,19 +58,22 @@ std::shared_ptr<MONITOR_CONNECTION_CONTEXT> MONITOR_SERVICE::start_monitoring(
         throw std::invalid_argument(msg);
     }
 
+    bool enable_logging = ds && ds->save_queries;
+
     std::shared_ptr<MONITOR> monitor = this->thread_container->get_or_create_monitor(
         node_keys,
         std::move(host),
         disposal_time,
         ds,
-        ds && ds->save_queries);
+        enable_logging);
 
     auto context = std::make_shared<MONITOR_CONNECTION_CONTEXT>(
         dbc,
         node_keys,
         failure_detection_time,
         failure_detection_interval,
-        failure_detection_count);
+        failure_detection_count,
+        enable_logging);
 
     monitor->start_monitoring(context);
     this->thread_container->add_task(monitor, shared_from_this());


### PR DESCRIPTION
### Jira Ticket

[RDS-1203]

### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete

### Summary

Enable logger for `MONITOR_CONNECTION_CONTEXT` the same way as `MONITOR`.

### Description

Previously the logger for `MONITOR_CONNECTION_CONTEXT` was enabled differently from the other monitor classes. Now it's enabled the same way.
