### PR TITLE
Update documentation to explain correct location of log file for Mac and Linux

### DIFF
--- a/docs/using-the-aws-driver/UsingTheAwsDriver.md
+++ b/docs/using-the-aws-driver/UsingTheAwsDriver.md
@@ -307,7 +307,7 @@ The resulting log file, named `myodbc.log`, can be found under `%temp%`.
 
 ### Enabling Logs On MacOS and Linux
 
-When connecting the AWS ODBC Driver for MySQL using a MacOS or Linux system, include the `LOG_QUERY` parameter in the connection string with the value of `1` to enable logging (`DSN=XXX;LOG_QUERY=1;...`). The log file, named `myodbc.log`, can be found in the current working directory.
+When connecting the AWS ODBC Driver for MySQL using a MacOS or Linux system, include the `LOG_QUERY` parameter in the connection string with the value of `1` to enable logging (`DSN=XXX;LOG_QUERY=1;...`). A log file, named `myodbc.log`, will be produced. On MacOS, the log file can be located in `/tmp`. On Linux, the log file can be found in the current working directory.
 
 >## :warning: Warnings About Proper Usage of the AWS ODBC Driver for MySQL
 >


### PR DESCRIPTION
### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete

### Summary

Update documentation to explain correct location of log file for Mac and Linux.

### Description

We previously stated that the log file can be found in the current working directory for Mac and Linux but this is not actually the case for Mac.
