### PR TITLE
Fix CMake Component name collision on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1005,7 +1005,7 @@ macro(bundle_plugins ignored)
     install(FILES "${lib}"
       CONFIGURATIONS Release RelWithDebInfo
       DESTINATION "${LIB_SUBDIR}/plugin"
-      COMPONENT ODBCDll
+      COMPONENT ODBCPlugin
     )
      
     configure_file(${lib} ${CMAKE_SOURCE_DIR}/wix/x64/plugin/${lib_name}.dll COPYONLY)


### PR DESCRIPTION
### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [ ] This is complete

### Summary
Mac installer can be built fine but cannot be installed before, see attached image, due to two CMake components with same name but in different cases, `OdbcDll` and `ODBCDll`.

https://github.com/awslabs/aws-mysql-odbc/blob/0a8aaca837d7681ebc3b32b18868be7e62462c84/CMakeLists.txt#L863-L867

https://github.com/awslabs/aws-mysql-odbc/blob/0a8aaca837d7681ebc3b32b18868be7e62462c84/CMakeLists.txt#L1005-L1008

<img width="372" alt="image" src="https://github.com/awslabs/aws-mysql-odbc/assets/68562925/ba2c5789-bf11-4876-b62b-30880301e636">
 
<!--- Short summary of the ticket. Should not be longer than two sentences. -->

### Description
- Renamed `ODBCDll` to `ODBCPlugin`
<!--- Description of the ticket. e.g., What is the ticket accomplishing, why is it important, what areas of the code does it affect, etc. -->

### Additional Reviewers
@alexr-bq @justing-bq 
<!-- Tag reviewers needed for this PR. -->
