### PR TITLE
Handle logging with and without variadic arguments

### DIFF
--- a/driver/mylog.h
+++ b/driver/mylog.h
@@ -42,11 +42,11 @@
   }
 
 #define MYLOG_DBC_TRACE(A, ...) \
-  { trace_print((A)->log_file, (A)->id, __VA_ARGS__); }
+  { trace_print_va_args((A)->log_file, (A)->id, __VA_ARGS__); }
 
-#define MYLOG_TRACE(A, B, ...)                            \
-  {                                                       \
-    if ((A) != nullptr) trace_print((A), B, __VA_ARGS__); \
+#define MYLOG_TRACE(A, B, ...)                                    \
+  {                                                               \
+    if ((A) != nullptr) trace_print_va_args((A), B, __VA_ARGS__); \
   }
 
 // stateless functor object for deleting FILE handle
@@ -65,6 +65,7 @@ extern std::mutex log_file_mutex;
 /* Functions used when debugging */
 std::shared_ptr<FILE> init_log_file();
 void end_log_file();
-void trace_print(std::shared_ptr<FILE> file, unsigned long dbc_id, const char *fmt, ...);
+void trace_print(std::shared_ptr<FILE> file, unsigned long dbc_id, const char *message);
+void trace_print_va_args(std::shared_ptr<FILE> file, unsigned long dbc_id, const char *fmt, ...);
 
 #endif /* __MYLOG_H__ */


### PR DESCRIPTION
### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete

### Summary

Handle logging with and without variadic arguments.

### Description

Previously we were using `trace_print()` to handle all log statements. Normally this works fine but it will crash if we ever log a statement that contains format specifiers (ie. `%s`, `%d`, etc) but there are no variadic arguments provided to substitute into those specifiers. Now we have defined `trace_print()` and `trace_print_va_args()` to handle each case separately and avoid this crash.