### PR TITLE
Revert performance test compiler change

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,14 +16,10 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       CMAKE_GENERATOR: Unix Makefiles
-      CXX: g++-7
 
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
-
-      - name: Install gcc7
-        run: sudo apt install g++-7
 
       # Configure build environment/dependencies
       - name: Install MySQL client libs & other dependencies


### PR DESCRIPTION
This change did not work with the performance test, as google test is not compiling with g++7.