### PR TITLE
chore: ensure regex is able to handle all types of china endpoints

### DIFF
--- a/driver/cluster_topology_info.cc
+++ b/driver/cluster_topology_info.cc
@@ -89,11 +89,11 @@ std::time_t CLUSTER_TOPOLOGY_INFO::time_last_updated() {
 
 // TODO harmonize time function across objects so the times are comparable
 void CLUSTER_TOPOLOGY_INFO::update_time() {
-    last_updated = time(0);
+    last_updated = time(nullptr);
 }
 
 std::shared_ptr<HOST_INFO> CLUSTER_TOPOLOGY_INFO::get_writer() {
-    if (writers.size() <= 0) {
+    if (writers.empty()) {
         throw std::runtime_error("No writer available");
     }
 
@@ -102,7 +102,7 @@ std::shared_ptr<HOST_INFO> CLUSTER_TOPOLOGY_INFO::get_writer() {
 
 std::shared_ptr<HOST_INFO> CLUSTER_TOPOLOGY_INFO::get_next_reader() {
     size_t num_readers = readers.size();
-    if (num_readers <= 0) {
+    if (readers.empty()) {
         throw std::runtime_error("No reader available");
     }
 

--- a/driver/failover_handler.cc
+++ b/driver/failover_handler.cc
@@ -66,22 +66,22 @@ const std::regex AURORA_CUSTOM_CLUSTER_PATTERN(
     R"#((.+)\.(cluster-custom-)+([a-zA-Z0-9]+\.[a-zA-Z0-9\-]+\.rds\.amazonaws\.com))#",
     std::regex_constants::icase);
 const std::regex AURORA_CHINA_DNS_PATTERN(
-    R"#((.+)\.(proxy-|cluster-|cluster-ro-|cluster-custom-)?([a-zA-Z0-9]+\.rds\.[a-zA-Z0-9\-]+\.amazonaws\.com\.cn))#",
+    R"#((.+)\.(proxy-|cluster-|cluster-ro-|cluster-custom-)?([a-zA-Z0-9]+\.(rds\.[a-zA-Z0-9\-]+|[a-zA-Z0-9\-]+\.rds)\.amazonaws\.com\.cn))#",
     std::regex_constants::icase);
 const std::regex AURORA_CHINA_PROXY_DNS_PATTERN(
-    R"#((.+)\.(proxy-)+([a-zA-Z0-9]+\.rds\.[a-zA-Z0-9\-]+\.amazonaws\.com\.cn))#",
+    R"#((.+)\.(proxy-)+([a-zA-Z0-9]+\.(rds\.[a-zA-Z0-9\-]+|[a-zA-Z0-9\-]+\.rds)\.amazonaws\.com\.cn))#",
     std::regex_constants::icase);
 const std::regex AURORA_CHINA_CLUSTER_PATTERN(
-    R"#((.+)\.(cluster-|cluster-ro-)+([a-zA-Z0-9]+\.rds\.[a-zA-Z0-9\-]+\.amazonaws\.com\.cn))#",
+    R"#((.+)\.(cluster-|cluster-ro-)+([a-zA-Z0-9]+\.(rds\.[a-zA-Z0-9\-]+|[a-zA-Z0-9\-]+\.rds)\.amazonaws\.com\.cn))#",
     std::regex_constants::icase);
 const std::regex AURORA_CHINA_WRITER_CLUSTER_PATTERN(
-    R"#((.+)\.(cluster-)+([a-zA-Z0-9]+\.rds\.[a-zA-Z0-9\-]+\.amazonaws\.com\.cn))#",
+    R"#((.+)\.(cluster-)+([a-zA-Z0-9]+\.(rds\.[a-zA-Z0-9\-]+|[a-zA-Z0-9\-]+\.rds)\.amazonaws\.com\.cn))#",
     std::regex_constants::icase);
 const std::regex AURORA_CHINA_READER_CLUSTER_PATTERN(
-    R"#((.+)\.(cluster-ro-)+([a-zA-Z0-9]+\.rds\.[a-zA-Z0-9\-]+\.amazonaws\.com\.cn))#",
+    R"#((.+)\.(cluster-ro-)+([a-zA-Z0-9]+\.(rds\.[a-zA-Z0-9\-]+|[a-zA-Z0-9\-]+\.rds)\.amazonaws\.com\.cn))#",
     std::regex_constants::icase);
 const std::regex AURORA_CHINA_CUSTOM_CLUSTER_PATTERN(
-    R"#((.+)\.(cluster-custom-)+([a-zA-Z0-9]+\.rds\.[a-zA-Z0-9\-]+\.amazonaws\.com\.cn))#",
+    R"#((.+)\.(cluster-custom-)+([a-zA-Z0-9]+\.(rds\.[a-zA-Z0-9\-]+|[a-zA-Z0-9\-]+\.rds)\.amazonaws\.com\.cn))#",
     std::regex_constants::icase);
 const std::regex IPV4_PATTERN(
     R"#(^(([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){1}(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){2}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$)#");
@@ -205,7 +205,7 @@ void FAILOVER_HANDLER::init_cluster_info() {
             throw std::runtime_error(err.str());
         }
 
-        if (host_patterns.size() == 0) {
+        if (host_patterns.empty()) {
             err << "Empty host pattern.";
             MYLOG_DBC_TRACE(dbc, err.str().c_str());
             throw std::runtime_error(err.str());


### PR DESCRIPTION
### Description
Typically the `rds` preceeds the `region` in the database endpoints, e.g. `abc.cluster-XYZ.rds.cn-northwest-1.amazonaws.com.cn`, but some older database endpoints have the `region` information in front of the `rds`, e.g.  `abc.cluster-XYZ.cn-northwest-1.rds.amazonaws.com.cn`
This PR updates regex pattern to ensure the driver accepts both types of china endpoints.

### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete

### Additional Reviewers

<!-- Tag reviewers needed for this PR. -->
