### PR TITLE
chore: always get gh action ip

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -87,6 +87,7 @@ jobs:
           DRIVER_PATH: ${{ github.workspace }}
 
       - name: 'Get Github Action IP'
+        if: always()
         id: ip
         uses: haythem/public-ip@v1.3
         

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -98,6 +98,7 @@ jobs:
           DRIVER_PATH: ${{ github.workspace }}
 
       - name: 'Get Github Action IP'
+        if: always()
         id: ip
         uses: haythem/public-ip@v1.3
         

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -76,6 +76,7 @@ jobs:
           DRIVER_PATH: ${{ github.workspace }}
 
       - name: 'Get Github Action IP'
+        if: always()
         id: ip
         uses: haythem/public-ip@v1.3
         


### PR DESCRIPTION
### Summary
Fixes issue when trying to remove GH Action runners IP from AWS Test Account's Security Group

### Description
Grabbing IP step is skipped if previous step failed (i.e. tests failed), and the subsequent step to remove IP from Security Groups will fail due to passing in a non-existent IP. Eventually this will fill up quota for IPs in the security group.

See the following before for recent scenarios of this happening.
- https://github.com/aws/aws-mysql-odbc/actions/runs/10494461306/job/29070757014
- https://github.com/aws/aws-mysql-odbc/actions/runs/10480247816/job/29027490776
- https://github.com/aws/aws-mysql-odbc/actions/runs/10475611331/job/29014552319

### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete
