### PR TITLE
refactor: simply connection string builder class so it is easier to update the class

### DIFF
--- a/.github/workflows/dockerized.yml
+++ b/.github/workflows/dockerized.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   community-tests:
     name: Dockerized Community Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CMAKE_GENERATOR: Unix Makefiles
 

--- a/integration/base_failover_integration_test.cc
+++ b/integration/base_failover_integration_test.cc
@@ -52,11 +52,13 @@
 #include <sql.h>
 #include <sqlext.h>
 
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
+#if defined(__APPLE__) || defined(__linux__)
+  #include <arpa/inet.h>
+  #include <netdb.h>
+  #include <netinet/in.h>
+  #include <sys/socket.h>
+  #include <sys/types.h>
+#endif
 
 #include "connection_string_builder.h"
 #include "integration_test_utils.h"
@@ -90,7 +92,7 @@ protected:
   int MYSQL_PROXY_PORT = INTEGRATION_TEST_UTILS::str_to_int(std::getenv("MYSQL_PROXY_PORT"));
   Aws::String cluster_id = MYSQL_CLUSTER_URL.substr(0, MYSQL_CLUSTER_URL.find('.'));
 
-  ConnectionStringBuilder builder;
+  std::string default_connection_string;
   std::string connection_string;
 
   SQLCHAR conn_in[4096] = "\0", conn_out[4096] = "\0", sqlstate[6] = "\0", message[SQL_MAX_MESSAGE_LENGTH] = "\0";

--- a/integration/connection_string_builder.h
+++ b/integration/connection_string_builder.h
@@ -24,7 +24,7 @@
 // See the GNU General Public License, version 2.0, for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with this program. If not, see 
+// along with this program. If not, see
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
 #ifndef __CONNECTIONSTRINGBUILDER_H__
@@ -32,444 +32,143 @@
 
 #include <stdexcept>
 #include <string>
-#include <memory>
-
-class ConnectionStringBuilder;
-
-class ConnectionString {
-  public:
-    // friend class so the builder can access ConnectionString private attributes
-    friend class ConnectionStringBuilder;
-
-    ConnectionString() : m_dsn(""), m_server(""), m_port(-1),
-                         m_uid(""), m_pwd(""), m_db(""), m_log_query(true),
-                         m_failover_mode(""), m_multi_statements(false), m_enable_cluster_failover(true),
-                         m_failover_timeout(-1), m_connect_timeout(-1), m_network_timeout(-1), m_host_pattern(""),
-                         m_enable_failure_detection(true), m_failure_detection_time(-1), m_failure_detection_timeout(-1),
-                         m_failure_detection_interval(-1), m_failure_detection_count(-1), m_monitor_disposal_time(-1),
-                         m_read_timeout(-1), m_write_timeout(-1), m_auth_mode(""), m_auth_region(""), m_auth_host(""),
-                         m_auth_port(-1), m_auth_expiration(-1), m_secret_id(""),
-                         
-                         is_set_uid(false), is_set_pwd(false), is_set_db(false), is_set_log_query(false),
-                         is_set_failover_mode(false),
-                         is_set_multi_statements(false), is_set_enable_cluster_failover(false),
-                         is_set_failover_timeout(false), is_set_connect_timeout(false), is_set_network_timeout(false), is_set_host_pattern(false),
-                         is_set_enable_failure_detection(false), is_set_failure_detection_time(false), is_set_failure_detection_timeout(false),
-                         is_set_failure_detection_interval(false), is_set_failure_detection_count(false), is_set_monitor_disposal_time(false),
-                         is_set_read_timeout(false), is_set_write_timeout(false), is_set_auth_mode(false), is_set_auth_region(false),
-                         is_set_auth_host(false), is_set_auth_port(false), is_set_auth_expiration(false), is_set_secret_id(false) {};
-
-    std::string get_connection_string() const {
-      char conn_in[4096] = "\0";
-      int length = 0;
-      length += sprintf(conn_in, "DSN=%s;SERVER=%s;PORT=%d;", m_dsn.c_str(), m_server.c_str(), m_port);
-
-      if (is_set_uid) {
-        length += sprintf(conn_in + length, "UID=%s;", m_uid.c_str()); 
-      }
-      if (is_set_pwd) {
-        length += sprintf(conn_in + length, "PWD=%s;", m_pwd.c_str()); 
-      }
-      if (is_set_db) {
-        length += sprintf(conn_in + length, "DATABASE=%s;", m_db.c_str()); 
-      }
-      if (is_set_log_query) {
-        length += sprintf(conn_in + length, "LOG_QUERY=%d;", m_log_query ? 1 : 0); 
-      }
-      if (is_set_failover_mode) {
-        length += sprintf(conn_in + length, "FAILOVER_MODE=%s;", m_failover_mode.c_str());
-      }
-      if (is_set_multi_statements) {
-        length += sprintf(conn_in + length, "MULTI_STATEMENTS=%d;", m_multi_statements ? 1 : 0);
-      }
-      if (is_set_enable_cluster_failover) {
-        length += sprintf(conn_in + length, "ENABLE_CLUSTER_FAILOVER=%d;", m_enable_cluster_failover ? 1 : 0);
-      }
-      if (is_set_failover_timeout) {
-        length += sprintf(conn_in + length, "FAILOVER_TIMEOUT=%d;", m_failover_timeout); 
-      }
-      if (is_set_connect_timeout) {
-        length += sprintf(conn_in + length, "CONNECT_TIMEOUT=%d;", m_connect_timeout); 
-      }
-      if (is_set_network_timeout) {
-        length += sprintf(conn_in + length, "NETWORK_TIMEOUT=%d;", m_network_timeout); 
-      }
-      if (is_set_host_pattern) {
-        length += sprintf(conn_in + length, "HOST_PATTERN=%s;", m_host_pattern.c_str()); 
-      }
-      if (is_set_enable_failure_detection) {
-        length += sprintf(conn_in + length, "ENABLE_FAILURE_DETECTION=%d;", m_enable_failure_detection ? 1 : 0); 
-      }
-      if (is_set_failure_detection_time) {
-        length += sprintf(conn_in + length, "FAILURE_DETECTION_TIME=%d;", m_failure_detection_time);
-      }
-      if (is_set_failure_detection_timeout) {
-        length += sprintf(conn_in + length, "FAILURE_DETECTION_TIMEOUT=%d;", m_failure_detection_timeout);
-      }
-      if (is_set_failure_detection_interval) {
-        length += sprintf(conn_in + length, "FAILURE_DETECTION_INTERVAL=%d;", m_failure_detection_interval);
-      }
-      if (is_set_failure_detection_count) {
-        length += sprintf(conn_in + length, "FAILURE_DETECTION_COUNT=%d;", m_failure_detection_count);
-      }
-      if (is_set_monitor_disposal_time) {
-        length += sprintf(conn_in + length, "MONITOR_DISPOSAL_TIME=%d;", m_monitor_disposal_time);
-      }
-      if (is_set_read_timeout) {
-        length += sprintf(conn_in + length, "READTIMEOUT=%d;", m_read_timeout);
-      }
-      if (is_set_write_timeout) {
-        length += sprintf(conn_in + length, "WRITETIMEOUT=%d;", m_write_timeout);
-      }
-      if (is_set_auth_mode) {
-        length += sprintf(conn_in + length, "AUTHENTICATION_MODE=%s;", m_auth_mode.c_str());
-      }
-      if (is_set_auth_region) {
-        length += sprintf(conn_in + length, "AWS_REGION=%s;", m_auth_region.c_str());
-      }
-      if (is_set_auth_host) {
-        length += sprintf(conn_in + length, "IAM_HOST=%s;", m_auth_host.c_str());
-      }
-      if (is_set_auth_port) {
-        length += sprintf(conn_in + length, "IAM_PORT=%d;", m_auth_port);
-      }
-      if (is_set_auth_expiration) {
-        length += sprintf(conn_in + length, "IAM_EXPIRATION_TIME=%d;", m_auth_expiration);
-      }
-      if (is_set_secret_id) {
-        length += sprintf(conn_in + length, "SECRET_ID=%s;", m_secret_id.c_str());
-      }
-      snprintf(conn_in + length, sizeof(conn_in) - length, "\0");
-
-      std::string connection_string(conn_in);
-      return connection_string;
-    }
-    
-  private:
-    // Required fields
-    std::string m_dsn, m_server;
-    int m_port;
-
-    // Optional fields
-    std::string m_uid, m_pwd, m_db;
-    bool m_log_query, m_multi_statements, m_enable_cluster_failover;
-    int m_failover_timeout, m_connect_timeout, m_network_timeout;
-    std::string m_host_pattern, m_failover_mode;
-    bool m_enable_failure_detection;
-    int m_failure_detection_time, m_failure_detection_timeout, m_failure_detection_interval, m_failure_detection_count, m_monitor_disposal_time, m_read_timeout, m_write_timeout;
-    std::string m_auth_mode, m_auth_region, m_auth_host, m_secret_id;
-    int m_auth_port, m_auth_expiration;
-
-    bool is_set_uid, is_set_pwd, is_set_db;
-    bool is_set_log_query, is_set_failover_mode, is_set_multi_statements;
-    bool is_set_enable_cluster_failover;
-    bool is_set_failover_timeout, is_set_connect_timeout, is_set_network_timeout;
-    bool is_set_host_pattern;
-    bool is_set_enable_failure_detection;
-    bool is_set_failure_detection_time, is_set_failure_detection_timeout, is_set_failure_detection_interval, is_set_failure_detection_count;
-    bool is_set_monitor_disposal_time;
-    bool is_set_read_timeout, is_set_write_timeout;
-    bool is_set_auth_mode, is_set_auth_region, is_set_auth_host, is_set_auth_port, is_set_auth_expiration, is_set_secret_id;
-
-    void set_dsn(const std::string& dsn) {
-      m_dsn = dsn;
-    }
-
-    void set_server(const std::string& server) {
-      m_server = server;
-    }
-
-    void set_port(const int& port) {
-      m_port = port;
-    }
-
-    void set_uid(const std::string& uid) {
-      m_uid = uid;
-      is_set_uid = true;
-    }
-
-    void set_pwd(const std::string& pwd) {
-      m_pwd = pwd;
-      is_set_pwd = true;
-    }
-
-    void set_db(const std::string& db) {
-      m_db = db;
-      is_set_db = true;
-    }
-
-    void set_log_query(const bool& log_query) {
-      m_log_query = log_query;
-      is_set_log_query = true;
-    }
-
-    void set_failover_mode(const std::string& failover_mode) {
-      m_failover_mode = failover_mode;
-      is_set_failover_mode = true;
-    }
-
-    void set_multi_statements(const bool& multi_statements) {
-      m_multi_statements = multi_statements;
-      is_set_multi_statements = true;
-    }
-
-    void set_enable_cluster_failover(const bool& enable_cluster_failover) {
-      m_enable_cluster_failover = enable_cluster_failover;
-      is_set_enable_cluster_failover = true;
-    }
-
-    void set_failover_timeout(const int& failover_timeout) {
-      m_failover_timeout = failover_timeout;
-      is_set_failover_timeout = true;
-    }
-
-    void set_connect_timeout(const int& connect_timeout) {
-      m_connect_timeout = connect_timeout;
-      is_set_connect_timeout = true;
-    }
-
-    void set_network_timeout(const int& network_timeout) {
-      m_network_timeout = network_timeout;
-      is_set_network_timeout = true;
-    }
-
-    void set_host_pattern(const std::string& host_pattern) {
-      m_host_pattern = host_pattern;
-      is_set_host_pattern = true;
-    }
-
-    void set_enable_failure_detection(const bool& enable_failure_detection) {
-      m_enable_failure_detection = enable_failure_detection;
-      is_set_enable_failure_detection = true;
-    }
-
-    void set_failure_detection_time(const int& failure_detection_time) {
-      m_failure_detection_time = failure_detection_time;
-      is_set_failure_detection_time = true;
-    }
-
-    void set_failure_detection_timeout(const int& failure_detection_timeout) {
-      m_failure_detection_timeout = failure_detection_timeout;
-      is_set_failure_detection_timeout = true;
-    }
-
-    void set_failure_detection_interval(const int& failure_detection_interval) {
-      m_failure_detection_interval = failure_detection_interval;
-      is_set_failure_detection_interval = true;
-    }
-
-    void set_failure_detection_count(const int& failure_detection_count) {
-      m_failure_detection_count = failure_detection_count;
-      is_set_failure_detection_count = true;
-    }
-
-    void set_monitor_disposal_time(const int& monitor_disposal_time) {
-      m_monitor_disposal_time = monitor_disposal_time;
-      is_set_monitor_disposal_time = true;
-    }
-
-    void set_read_timeout(const int& read_timeout) {
-      m_read_timeout = read_timeout;
-      is_set_read_timeout = true;
-    }
-
-    void set_write_timeout(const int& write_timeout) {
-      m_write_timeout = write_timeout;
-      is_set_write_timeout = true;
-    }
-
-    void set_auth_mode(const std::string& auth_mode) {
-        m_auth_mode = auth_mode;
-        is_set_auth_mode = true;
-    }
-
-    void set_auth_region(const std::string& auth_region) {
-        m_auth_region = auth_region;
-        is_set_auth_region = true;
-    }
-
-    void set_auth_host(const std::string& auth_host) {
-        m_auth_host = auth_host;
-        is_set_auth_host = true;
-    }
-
-    void set_auth_port(const int& auth_port) {
-        m_auth_port = auth_port;
-        is_set_auth_port = true;
-    }
-
-    void set_auth_expiration(const int& auth_expiration) {
-        m_auth_expiration = auth_expiration;
-        is_set_auth_expiration = true;
-    }
-
-    void set_secret_id(const std::string& secret_id) {
-        m_secret_id = secret_id;
-        is_set_secret_id = true;
-    }
-};
 
 class ConnectionStringBuilder {
-  public:
-    ConnectionStringBuilder() {
-      connection_string.reset(new ConnectionString());
-    }
-    
-    ConnectionStringBuilder& withDSN(const std::string& dsn) {
-      connection_string->set_dsn(dsn);
-      return *this;
-    }
+ public:
+  ConnectionStringBuilder(const std::string& dsn, const std::string& server, int port) {
+    length += sprintf(conn_in, "DSN=%s;SERVER=%s;PORT=%d;", dsn.c_str(), server.c_str(), port);
+  }
 
-    ConnectionStringBuilder& withServer(const std::string& server) {
-      connection_string->set_server(server);
-      return *this;
-    }
+  ConnectionStringBuilder& withUID(const std::string& uid) {
+    length += sprintf(conn_in + length, "UID=%s;", uid.c_str());
+    return *this;
+  }
 
-    ConnectionStringBuilder& withPort(const int& port) {
-      connection_string->set_port(port);
-      return *this;
-    }
-    
-    ConnectionStringBuilder& withUID(const std::string& uid) {
-      connection_string->set_uid(uid);
-      return *this;
-    }
+  ConnectionStringBuilder& withPWD(const std::string& pwd) {
+    length += sprintf(conn_in + length, "PWD=%s;", pwd.c_str());
+    return *this;
+  }
 
-    ConnectionStringBuilder& withPWD(const std::string& pwd) {
-      connection_string->set_pwd(pwd);
-      return *this;
-    }
+  ConnectionStringBuilder& withDatabase(const std::string& db) {
+    length += sprintf(conn_in + length, "DATABASE=%s;", db.c_str());
+    return *this;
+  }
 
-    ConnectionStringBuilder& withDatabase(const std::string& db) {
-      connection_string->set_db(db);
-      return *this;
-    }
+  ConnectionStringBuilder& withLogQuery(const bool& log_query) {
+    length += sprintf(conn_in + length, "LOG_QUERY=%d;", log_query ? 1 : 0);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withLogQuery(const bool& log_query) {
-      connection_string->set_log_query(log_query);
-      return *this;
-    }
+  ConnectionStringBuilder& withFailoverMode(const std::string& failover_mode) {
+    length += sprintf(conn_in + length, "FAILOVER_MODE=%s;", failover_mode.c_str());
+    return *this;
+  }
 
-    ConnectionStringBuilder& withFailoverMode(const std::string& failover_mode) {
-      connection_string->set_failover_mode(failover_mode);
-      return *this;
-    }
+  ConnectionStringBuilder& withMultiStatements(const bool& multi_statements) {
+    length += sprintf(conn_in + length, "MULTI_STATEMENTS=%d;", multi_statements ? 1 : 0);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withMultiStatements(const bool& multi_statements) {
-      connection_string->set_multi_statements(multi_statements);
-      return *this;
-    }
+  ConnectionStringBuilder& withEnableClusterFailover(const bool& enable_cluster_failover) {
+    length += sprintf(conn_in + length, "ENABLE_CLUSTER_FAILOVER=%d;", enable_cluster_failover ? 1 : 0);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withEnableClusterFailover(const bool& enable_cluster_failover) {
-      connection_string->set_enable_cluster_failover(enable_cluster_failover);
-      return *this;
-    }
+  ConnectionStringBuilder& withFailoverTimeout(const int& failover_t) {
+    length += sprintf(conn_in + length, "FAILOVER_TIMEOUT=%d;", failover_t);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withFailoverTimeout(const int& failover_t) {
-      connection_string->set_failover_timeout(failover_t);
-      return *this;
-    }
+  ConnectionStringBuilder& withConnectTimeout(const int& connect_timeout) {
+    length += sprintf(conn_in + length, "CONNECT_TIMEOUT=%d;", connect_timeout);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withConnectTimeout(const int& connect_timeout) {
-      connection_string->set_connect_timeout(connect_timeout);
-      return *this;
-    }
+  ConnectionStringBuilder& withNetworkTimeout(const int& network_timeout) {
+    length += sprintf(conn_in + length, "NETWORK_TIMEOUT=%d;", network_timeout);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withNetworkTimeout(const int& network_timeout) {
-      connection_string->set_network_timeout(network_timeout);
-      return *this;
-    }
+  ConnectionStringBuilder& withHostPattern(const std::string& host_pattern) {
+    length += sprintf(conn_in + length, "HOST_PATTERN=%s;", host_pattern.c_str());
+    return *this;
+  }
 
-    ConnectionStringBuilder& withHostPattern(const std::string& host_pattern) {
-      connection_string->set_host_pattern(host_pattern);
-      return *this;
-    }
+  ConnectionStringBuilder& withEnableFailureDetection(const bool& enable_failure_detection) {
+    length += sprintf(conn_in + length, "ENABLE_FAILURE_DETECTION=%d;", enable_failure_detection ? 1 : 0);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withEnableFailureDetection(const bool& enable_failure_detection) {
-      connection_string->set_enable_failure_detection(enable_failure_detection);
-      return *this;
-    }
+  ConnectionStringBuilder& withFailureDetectionTime(const int& failure_detection_time) {
+    length += sprintf(conn_in + length, "FAILURE_DETECTION_TIME=%d;", failure_detection_time);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withFailureDetectionTime(const int& failure_detection_time) {
-      connection_string->set_failure_detection_time(failure_detection_time);
-      return *this;
-    }
+  ConnectionStringBuilder& withFailureDetectionTimeout(const int& failure_detection_timeout) {
+    length += sprintf(conn_in + length, "FAILURE_DETECTION_TIMEOUT=%d;", failure_detection_timeout);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withFailureDetectionTimeout(const int& failure_detection_timeout) {
-      connection_string->set_failure_detection_timeout(failure_detection_timeout);
-      return *this;
-    }
+  ConnectionStringBuilder& withFailureDetectionInterval(const int& failure_detection_interval) {
+    length += sprintf(conn_in + length, "FAILURE_DETECTION_INTERVAL=%d;", failure_detection_interval);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withFailureDetectionInterval(const int& failure_detection_interval) {
-      connection_string->set_failure_detection_interval(failure_detection_interval);
-      return *this;
-    }
+  ConnectionStringBuilder& withFailureDetectionCount(const int& failure_detection_count) {
+    length += sprintf(conn_in + length, "FAILURE_DETECTION_COUNT=%d;", failure_detection_count);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withFailureDetectionCount(const int& failure_detection_count) {
-      connection_string->set_failure_detection_count(failure_detection_count);
-      return *this;
-    }
+  ConnectionStringBuilder& withMonitorDisposalTime(const int& monitor_disposal_time) {
+    length += sprintf(conn_in + length, "MONITOR_DISPOSAL_TIME=%d;", monitor_disposal_time);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withMonitorDisposalTime(const int& monitor_disposal_time) {
-      connection_string->set_monitor_disposal_time(monitor_disposal_time);
-      return *this;
-    }
+  ConnectionStringBuilder& withReadTimeout(const int& read_timeout) {
+    length += sprintf(conn_in + length, "READTIMEOUT=%d;", read_timeout);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withReadTimeout(const int& read_timeout) {
-      connection_string->set_read_timeout(read_timeout);
-      return *this;
-    }
-    
-    ConnectionStringBuilder& withWriteTimeout(const int& write_timeout) {
-      connection_string->set_write_timeout(write_timeout);
-      return *this;
-    }
+  ConnectionStringBuilder& withWriteTimeout(const int& write_timeout) {
+    length += sprintf(conn_in + length, "WRITETIMEOUT=%d;", write_timeout);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withAuthMode(const std::string& auth_mode) {
-      connection_string->set_auth_mode(auth_mode);
-      return *this;
-    }
+  ConnectionStringBuilder& withAuthMode(const std::string& auth_mode) {
+    length += sprintf(conn_in + length, "AUTHENTICATION_MODE=%s;", auth_mode.c_str());
+    return *this;
+  }
 
-    ConnectionStringBuilder& withAuthRegion(const std::string& auth_region) {
-        connection_string->set_auth_region(auth_region);
-        return *this;
-    }
+  ConnectionStringBuilder& withAuthRegion(const std::string& auth_region) {
+    length += sprintf(conn_in + length, "AWS_REGION=%s;", auth_region.c_str());
+    return *this;
+  }
 
-    ConnectionStringBuilder& withAuthHost(const std::string& auth_host) {
-        connection_string->set_auth_host(auth_host);
-        return *this;
-    }
+  ConnectionStringBuilder& withAuthHost(const std::string& auth_host) {
+    length += sprintf(conn_in + length, "IAM_HOST=%s;", auth_host.c_str());
+    return *this;
+  }
 
-    ConnectionStringBuilder& withAuthPort(const int& auth_port) {
-        connection_string->set_auth_port(auth_port);
-        return *this;
-    }
+  ConnectionStringBuilder& withAuthPort(const int& auth_port) {
+    length += sprintf(conn_in + length, "IAM_PORT=%d;", auth_port);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withAuthExpiration(const int& auth_expiration) {
-        connection_string->set_auth_expiration(auth_expiration);
-        return *this;
-    }
+  ConnectionStringBuilder& withAuthExpiration(const int& auth_expiration) {
+    length += sprintf(conn_in + length, "IAM_EXPIRATION_TIME=%d;", auth_expiration);
+    return *this;
+  }
 
-    ConnectionStringBuilder& withSecretId(const std::string& secret_id) {
-        connection_string->set_secret_id(secret_id);
-        return *this;
-    }
+  ConnectionStringBuilder& withSecretId(const std::string& secret_id) {
+    length += sprintf(conn_in + length, "SECRET_ID=%s;", secret_id.c_str());
+    return *this;
+  }
 
-    std::string build() const {
-      if (connection_string->m_dsn.empty()) {
-        throw std::runtime_error("DSN is a required field in a connection string.");
-      }
-      if (connection_string->m_server.empty()) {
-        throw std::runtime_error("Server is a required field in a connection string.");
-      }
-      if (connection_string->m_port < 1) {
-        throw std::runtime_error("Port is a required field in a connection string.");
-      }
-      return connection_string->get_connection_string();
-    }
-    
-  private:
-    std::unique_ptr<ConnectionString> connection_string;
+  std::string get_string() const { return conn_in; }
+
+ private:
+  char conn_in[4096] = "\0";
+  int length = 0;
 };
 
 #endif /* __CONNECTIONSTRINGBUILDER_H__ */

--- a/integration/connection_string_builder.h
+++ b/integration/connection_string_builder.h
@@ -39,6 +39,8 @@ class ConnectionStringBuilder {
     length += sprintf(conn_in, "DSN=%s;SERVER=%s;PORT=%d;", dsn.c_str(), server.c_str(), port);
   }
 
+  ConnectionStringBuilder(const std::string& str) { length += sprintf(conn_in, "%s", str.c_str()); }
+
   ConnectionStringBuilder& withUID(const std::string& uid) {
     length += sprintf(conn_in + length, "UID=%s;", uid.c_str());
     return *this;
@@ -164,7 +166,7 @@ class ConnectionStringBuilder {
     return *this;
   }
 
-  std::string get_string() const { return conn_in; }
+  std::string getString() const { return conn_in; }
 
  private:
   char conn_in[4096] = "\0";

--- a/integration/connection_string_builder_test.cc
+++ b/integration/connection_string_builder_test.cc
@@ -51,7 +51,7 @@ TEST_F(ConnectionStringBuilderTest, test_complete_string) {
                                             .withFailureDetectionCount(4)
                                             .withMonitorDisposalTime(300)
                                             .withEnableClusterFailover(true)
-                                            .get_string();
+                                            .getString();
 
   const std::string expected =
       "DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;DATABASE=testDb;LOG_QUERY=0;MULTI_STATEMENTS=0;"
@@ -64,7 +64,7 @@ TEST_F(ConnectionStringBuilderTest, test_complete_string) {
 // No optional fields are set in the builder. Build will succeed. Connection string with required fields.
 TEST_F(ConnectionStringBuilderTest, test_only_required_fields) {
   ConnectionStringBuilder builder("testDSN", "testServer", 3306);
-  const std::string connection_string = builder.get_string();
+  const std::string connection_string = builder.getString();
 
   const std::string expected = "DSN=testDSN;SERVER=testServer;PORT=3306;";
   EXPECT_EQ(0, expected.compare(connection_string));
@@ -74,7 +74,7 @@ TEST_F(ConnectionStringBuilderTest, test_only_required_fields) {
 // Connection string with required fields and ONLY the fields that were set.
 TEST_F(ConnectionStringBuilderTest, test_some_optional) {
   ConnectionStringBuilder builder("testDSN", "testServer", 3306);
-  const std::string connection_string = builder.withUID("testUser").withPWD("testPwd").get_string();
+  const std::string connection_string = builder.withUID("testUser").withPWD("testPwd").getString();
 
   const std::string expected("DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;");
   EXPECT_EQ(0, expected.compare(connection_string));
@@ -89,7 +89,7 @@ TEST_F(ConnectionStringBuilderTest, test_setting_boolean_fields) {
                                             .withMultiStatements(true)
                                             .withEnableClusterFailover(false)
                                             .withEnableFailureDetection(true)
-                                            .get_string();
+                                            .getString();
 
   const std::string expected(
       "DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;LOG_QUERY=0;MULTI_STATEMENTS=1;ENABLE_CLUSTER_"
@@ -101,7 +101,7 @@ TEST_F(ConnectionStringBuilderTest, test_setting_boolean_fields) {
 // Build will succeed.
 TEST_F(ConnectionStringBuilderTest, test_setting_multiple_steps_1) {
   ConnectionStringBuilder builder("testDSN", "testServer", 3306);
-  const std::string connection_string = builder.withUID("testUser").withPWD("testPwd").withLogQuery(true).get_string();
+  const std::string connection_string = builder.withUID("testUser").withPWD("testPwd").withLogQuery(true).getString();
 
   const std::string expected("DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;LOG_QUERY=1;");
   EXPECT_EQ(0, expected.compare(connection_string));

--- a/integration/connection_string_builder_test.cc
+++ b/integration/connection_string_builder_test.cc
@@ -38,10 +38,11 @@ TEST_F(ConnectionStringBuilderTest, test_complete_string) {
   ConnectionStringBuilder builder("testDSN", "testServer", 3306);
   const std::string connection_string = builder.withUID("testUser")
                                             .withPWD("testPwd")
+                                            .withDatabase("testDb")
                                             .withLogQuery(false)
                                             .withMultiStatements(false)
+                                            .withEnableClusterFailover(true)
                                             .withFailoverTimeout(120000)
-                                            .withDatabase("testDb")
                                             .withConnectTimeout(20)
                                             .withNetworkTimeout(20)
                                             .withHostPattern("?.testDomain")
@@ -50,7 +51,6 @@ TEST_F(ConnectionStringBuilderTest, test_complete_string) {
                                             .withFailureDetectionInterval(100)
                                             .withFailureDetectionCount(4)
                                             .withMonitorDisposalTime(300)
-                                            .withEnableClusterFailover(true)
                                             .getString();
 
   const std::string expected =


### PR DESCRIPTION
### Summary
The current implementation is bloated with repetitive and verbose code. Adding a new connection variable requires adding 2 new methods, 2 new variables, and 1 new if condition.
After this change we only need to add 1 method for new variables.
This change also updates the constructor so requires parameters must be passed in through the constructor, thus reducing number of checks required.

### Description

<!--- Description of the ticket. e.g., What is the ticket accomplishing, why is it important, what areas of the code does it affect, etc. -->

### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [x] This is ready for review
- [x] This is complete

### Additional Reviewers

<!-- Tag reviewers needed for this PR. -->
