### PR TITLE
chore: use oidc for aws cred

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -86,7 +86,7 @@ jobs:
       
       - name: Upload Windows installer as artifact
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: installers
           path: ${{ github.workspace }}/wix/*.msi

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -6,6 +6,10 @@ env:
   BUILD_TYPE: Release
   DRIVER_VERSION: 1.1.0
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-windows:
     name: Windows

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run build installer script
         shell: pwsh
         run: |
-          .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}"
+          .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}" "C:/openssl-3/x64/include/"
 
       - name: Configure AWS credentials OIDC
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -55,16 +55,22 @@ jobs:
         run: |
           .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}"
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
+      - name: Configure AWS credentials OIDC
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-skip-session-tagging: true
-          aws-access-key-id: ${{ secrets.AWS_BUILD_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_BUILD_SECRET_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: mysql-win-signer
+
+      - name: Configure AWS credentials Signer
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-skip-session-tagging: true
+          role-chaining: true
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-          role-duration-seconds: 3600
 
       - name: Run signer script
         shell: pwsh

--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -6,6 +6,10 @@ on:
 env:
   BUILD_TYPE: Release
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   integration-tests-codebuild:
     strategy:

--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -52,23 +52,9 @@ jobs:
       - name: 'Configure AWS Credentials'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: 'Set up Temp AWS Credentials'
-        run: |
-          creds=($(aws sts get-session-token \
-            --duration-seconds 21600 \
-            --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' \
-            --output text \
-          | xargs));
-          echo "::add-mask::${creds[0]}"
-          echo "::add-mask::${creds[1]}"
-          echo "::add-mask::${creds[2]}"
-          echo "TEMP_AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: mysql-codebuild-integration
 
       - name: 'Run Integration Tests'
         working-directory: ${{ github.workspace }}/testframework
@@ -78,9 +64,6 @@ jobs:
           TEST_DSN: awsmysqlodbca
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
           DB_ENGINE_VERSION: ${{ matrix.engine_version }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           RDS_ENDPOINT: ${{ secrets.RDS_ENDPOINT }}

--- a/.github/workflows/failover.yml
+++ b/.github/workflows/failover.yml
@@ -22,6 +22,10 @@ env:
   WINDOWS_BUILD_TYPE: Debug
   MAC_BUILD_TYPE: Debug
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-windows:
     name: Windows

--- a/.github/workflows/failover.yml
+++ b/.github/workflows/failover.yml
@@ -22,10 +22,6 @@ env:
   WINDOWS_BUILD_TYPE: Debug
   MAC_BUILD_TYPE: Debug
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   build-windows:
     name: Windows

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,23 +66,9 @@ jobs:
       - name: 'Configure AWS Credentials'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: 'Set up Temp AWS Credentials'
-        run: |
-          creds=($(aws sts get-session-token \
-            --duration-seconds 21600 \
-            --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' \
-            --output text \
-          | xargs));
-          echo "::add-mask::${creds[0]}"
-          echo "::add-mask::${creds[1]}"
-          echo "::add-mask::${creds[2]}"
-          echo "TEMP_AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: mysql-linux-integration
 
       - name: 'Run Integration Tests'
         working-directory: ${{ github.workspace }}/testframework
@@ -92,9 +78,6 @@ jobs:
           TEST_DSN: awsmysqlodbca
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
           DB_ENGINE_VERSION: ${{ matrix.engine_version }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           DRIVER_PATH: ${{ github.workspace }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,12 +55,6 @@ jobs:
             aws_sdk
           key: ${{ runner.os }}-aws-sdk-dynamic-lib
 
-      - name: Build and install AWS SDK C++
-        working-directory: ./scripts
-        if: steps.cache-dynamic-aws-sdk.outputs.cache-hit != 'true'
-        run: |
-          ./build_aws_sdk_unix.sh $BUILD_TYPE
-
       - name: 'Set up JDK'
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,6 +26,10 @@ concurrency:
   group: environment-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   integration-tests:
     strategy:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -7,6 +7,10 @@ on:
 env:
   BUILD_TYPE: Release
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-dockerized-performance-tests:
     concurrency: # Cancel previous runs in the same branch

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -44,23 +44,9 @@ jobs:
       - name: 'Configure AWS Credentials'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: 'Set up Temp AWS Credentials'
-        run: |
-          creds=($(aws sts get-session-token \
-            --duration-seconds 21600 \
-            --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' \
-            --output text \
-          | xargs));
-          echo "::add-mask::${creds[0]}"
-          echo "::add-mask::${creds[1]}"
-          echo "::add-mask::${creds[2]}"
-          echo "TEMP_AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: mysql-linux-integration
 
       - name: 'Run Performance Tests'
         working-directory: ${{ github.workspace }}/testframework
@@ -70,9 +56,6 @@ jobs:
           TEST_DSN: awsmysqlodbca
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
           DRIVER_PATH: ${{ github.workspace }}
 
       - name: 'Get Github Action IP'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,16 +242,22 @@ jobs:
         run: |
           .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}" C:/openssl-3/x64/include/
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
+      - name: Configure AWS credentials OIDC
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-skip-session-tagging: true
-          aws-access-key-id: ${{ secrets.AWS_BUILD_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_BUILD_SECRET_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: mysql-win-signer
+
+      - name: Configure AWS credentials Signer
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-skip-session-tagging: true
+          role-chaining: true
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-          role-duration-seconds: 3600
 
       - name: Run signer script
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 env:
   BUILD_TYPE: Release
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-mac:
     name: macOS

--- a/scripts/sign_installer.ps1
+++ b/scripts/sign_installer.ps1
@@ -32,6 +32,7 @@ function Invoke-SignFile {
     # Upload unsigned .msi to S3 Bucket
     Write-Host "Obtaining version id and uploading unsigned .msi to S3 Bucket"
     $versionId = $( aws s3api put-object --bucket $AwsUnsignedBucket --key $AwsKey --body $SourcePath --acl bucket-owner-full-control | jq '.VersionId' )
+    $versionId = $versionId.Replace("`"","")
     $jobId = ""
 
     if ([string]::IsNullOrEmpty($versionId)) {


### PR DESCRIPTION
### Summary

Updates AWS Credentials to OIDC

### Description

- Fetches credentials from OIDC provider and removes use of long lived credentials
- For Dockerized Integration tests
   - Removed the AWS SDK build within the GH Workflow and rely solely on the build within the Dockerized container. The Ubuntu image used by GitHub & Docker are not the same and will eventually cause issues when building the integration tests.
- Signer Script
  - The whole file seems changed due to the different EOL Sequence.
  - Minor change in the signer script to remove quotations from the AWS output for Job ID. See line 75.

### Testing

- [x] Release Workflow, https://github.com/aws/aws-mysql-odbc/actions/runs/15151517438
- [x] Integration Test Workflows
