### PR TITLE
Update OpenSSL version to 3.5.5 in workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -29,7 +29,7 @@ jobs:
       
       - name: Install OpenSSL 3
         run: |
-          curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.3.1.zip -o openssl3.zip
+          curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
           unzip -d C:/ openssl3.zip
           cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
           cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
-          unzip -d C:/ openssl3.zip
+          mkdir C:/openssl-3.5.5
+          unzip -d C:/openssl-3.5.5 openssl3.zip
           cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
           cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -31,8 +31,8 @@ jobs:
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
           unzip -d C:/ openssl3.zip
-          cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
-          cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -57,7 +57,7 @@ jobs:
       - name: Run build installer script
         shell: pwsh
         run: |
-          .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}" "C:/openssl-3/x64/include/"
+          .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}" "C:/openssl-3.5.5/x64/include/"
 
       - name: Configure AWS credentials OIDC
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
-          mkdir C:/openssl-3.5.5
-          unzip -d C:/openssl-3.5.5 openssl3.zip
-          cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
-          cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
+          mkdir C:/openssl-3
+          unzip -d C:/openssl-3 openssl3.zip
+          cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -58,7 +58,7 @@ jobs:
       - name: Run build installer script
         shell: pwsh
         run: |
-          .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}" "C:/openssl-3.5.5/x64/include/"
+          .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}" "C:/openssl-3/x64/include/"
 
       - name: Configure AWS credentials OIDC
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
+          echo "3739c845f86906eed4b8e1c321a240a756e2eb5140537cddc796a85e36dc71d9  openssl3.zip" | shasum -a 256 -c
           mkdir C:/openssl-3
           unzip -d C:/openssl-3 openssl3.zip
           cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -19,7 +19,7 @@ jobs:
       WIX_DIR: "C:/Program Files (x86)/WiX Toolset v3.14/bin"
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Configure build environment/dependencies
       - name: Install MySQL client libs
@@ -37,11 +37,11 @@ jobs:
           cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             aws_sdk
@@ -54,7 +54,7 @@ jobs:
           .\build_aws_sdk_win.ps1 x64 ${{ env.BUILD_TYPE}} ON "${{env.CMAKE_GENERATOR}}"
 
       - name: Setup nmake
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
 
       - name: Run build installer script
         shell: pwsh
@@ -62,7 +62,7 @@ jobs:
           .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}" "C:/openssl-3/x64/include/"
 
       - name: Configure AWS credentials OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-skip-session-tagging: true
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -70,7 +70,7 @@ jobs:
           role-session-name: mysql-win-signer
 
       - name: Configure AWS credentials Signer
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-skip-session-tagging: true
           role-chaining: true
@@ -88,7 +88,7 @@ jobs:
       
       - name: Upload Windows installer as artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: installers
           path: ${{ github.workspace }}/wix/*.msi

--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -28,14 +28,14 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4 && sudo apt-get install libcurl4-openssl-dev
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             aws_sdk
@@ -48,13 +48,13 @@ jobs:
           ./build_aws_sdk_unix.sh $BUILD_TYPE
 
       - name: 'Set up JDK'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'corretto'
           java-version: 17
 
       - name: 'Configure AWS Credentials'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -76,7 +76,7 @@ jobs:
       - name: 'Get Github Action IP'
         if: always()
         id: ip
-        uses: haythem/public-ip@v1.3
+        uses: haythem/public-ip@bdddd92c198b0955f0b494a8ebeac529754262ff # v1.3
         
       - name: 'Remove Github Action IP'
         if: always()
@@ -101,7 +101,7 @@ jobs:
 
       - name: 'Archive log results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: 'integration-test-logs'
           path: reports/tests/

--- a/.github/workflows/dockerized.yml
+++ b/.github/workflows/dockerized.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4 && sudo apt-get install libcurl4-openssl-dev
@@ -41,7 +41,7 @@ jobs:
           ./build_aws_sdk_unix.sh $BUILD_TYPE
 
       - name: 'Set up JDK'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'corretto'
           java-version: 17

--- a/.github/workflows/failover.yml
+++ b/.github/workflows/failover.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
-          mkdir C:/openssl-3.5.5
-          unzip -d C:/openssl-3.5.5 openssl3.zip
+          mkdir C:/openssl-3
+          unzip -d C:/openssl-3 openssl3.zip
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -78,9 +78,9 @@ jobs:
                 -DMYSQLCLIENT_STATIC_LINKING=TRUE
                 -DENABLE_UNIT_TESTS=TRUE
                 -DENABLE_INTEGRATION_TESTS=FALSE
-                -DOPENSSL_INCLUDE_DIR="C:/openssl-3.5.5/x64/include/"
-                -DOPENSSL_LIBRARY="C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll"
-                -DCRYPTO_LIBRARY="C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll"
+                -DOPENSSL_INCLUDE_DIR="C:/openssl-3/x64/include/"
+                -DOPENSSL_LIBRARY="C:/openssl-3/x64/bin/libssl-3-x64.dll"
+                -DCRYPTO_LIBRARY="C:/openssl-3/x64/bin/libcrypto-3-x64.dll"
 
       # Configure test environment
       - name: Build Driver
@@ -223,7 +223,7 @@ jobs:
 
   build-mac:
     name: MacOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       CMAKE_GENERATOR: Unix Makefiles
       ODBC_DM_INCLUDES: /usr/local/include

--- a/.github/workflows/failover.yml
+++ b/.github/workflows/failover.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
-          unzip -d C:/ openssl3.zip
+          mkdir C:/openssl-3.5.5
+          unzip -d C:/openssl-3.5.5 openssl3.zip
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/failover.yml
+++ b/.github/workflows/failover.yml
@@ -35,7 +35,7 @@ jobs:
       MYSQL_DIR: C:/mysql-${{ vars.MYSQL_VERSION }}-winx64
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Configure build environment/dependencies
       - name: Install MySQL client libs and include files
@@ -55,11 +55,11 @@ jobs:
           unzip -d C:/openssl-3 openssl3.zip
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
       - name: Cache AWS SDK libraries
         id: cache-static-aws-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             aws_sdk
@@ -112,25 +112,25 @@ jobs:
       # Upload artifacts
       - name: Upload build artifacts - Binaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-failover-sln
           path: ${{ github.workspace }}/build/MySQL_Connector_ODBC.sln
       - name: Upload build artifacts - Binaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-failover-binaries
           path: ${{ github.workspace }}/build/bin/
       - name: Upload build artifacts - Libraries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-failover-libraries
           path: ${{ github.workspace }}/build/lib/
       - name: Upload failover test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-failover-results
           path: ${{ github.workspace }}/build/unit_testing/Testing/Temporary/LastTest.log
@@ -143,7 +143,7 @@ jobs:
 #      CXX: g++-11
 #    steps:
 #      - name: Checkout source code
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 #
 #      # Configure build environment/dependencies
 #      - name: Install build dependencies
@@ -162,7 +162,7 @@ jobs:
 #
 #      - name: Cache AWS SDK libraries
 #        id: cache-dynamic-aws-sdk
-#        uses: actions/cache@v4
+#        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
 #        with:
 #          path: |
 #            aws_sdk
@@ -209,19 +209,19 @@ jobs:
 #      # Upload artifacts
 #      - name: Upload build artifacts - Binaries
 #        if: always()
-#        uses: actions/upload-artifact@v4
+#        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
 #        with:
 #          name: linux-failover-binaries
 #          path: ${{ github.workspace }}/build/bin/
 #      - name: Upload build artifacts - Libraries
 #        if: always()
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
 #        with:
 #          name: linux-failover-libraries
 #          path: ${{ github.workspace }}/build/lib/
 #      - name: Upload test artifacts
 #        if: always()
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
 #        with:
 #          name: linux-failover-results
 #          path: ${{ github.workspace }}/build/unit_testing/Testing/Temporary/LastTest.log
@@ -234,7 +234,7 @@ jobs:
       ODBC_DM_INCLUDES: /usr/local/include
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Configure build environment/dependencies
       # Removing some /usr/local/bin files to avoid symlink issues wih brew update
@@ -269,7 +269,7 @@ jobs:
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             aws_sdk
@@ -326,25 +326,25 @@ jobs:
       # Upload artifacts
       - name: Upload build artifacts - Binaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-binaries
           path: ${{ github.workspace }}/build/bin/
       - name: Upload build artifacts - Libraries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-libraries
           path: ${{ github.workspace }}/build/lib/
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-failover-results
           path: ${{ github.workspace }}/build/unit_testing/Testing/Temporary/LastTest.log
       - name: Upload memory leaks check
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-memory-leaks-results
           path: ${{ github.workspace }}/build/unit_testing/leaks_unit_testing.txt

--- a/.github/workflows/failover.yml
+++ b/.github/workflows/failover.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install OpenSSL 3
         run: |
-          curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.3.1.zip -o openssl3.zip
+          curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
           unzip -d C:/ openssl3.zip
 
       - name: Add msbuild to PATH

--- a/.github/workflows/failover.yml
+++ b/.github/workflows/failover.yml
@@ -77,9 +77,9 @@ jobs:
                 -DMYSQLCLIENT_STATIC_LINKING=TRUE
                 -DENABLE_UNIT_TESTS=TRUE
                 -DENABLE_INTEGRATION_TESTS=FALSE
-                -DOPENSSL_INCLUDE_DIR="C:/openssl-3/x64/include/"
-                -DOPENSSL_LIBRARY="C:/openssl-3/x64/bin/libssl-3-x64.dll"
-                -DCRYPTO_LIBRARY="C:/openssl-3/x64/bin/libcrypto-3-x64.dll"
+                -DOPENSSL_INCLUDE_DIR="C:/openssl-3.5.5/x64/include/"
+                -DOPENSSL_LIBRARY="C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll"
+                -DCRYPTO_LIBRARY="C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll"
 
       # Configure test environment
       - name: Build Driver

--- a/.github/workflows/failover.yml
+++ b/.github/workflows/failover.yml
@@ -17,6 +17,10 @@ on:
       - 'ISSUE_TEMPLATE/**'
       - '**/remove-old-artifacts.yml'
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   LINUX_BUILD_TYPE: Release
   WINDOWS_BUILD_TYPE: Debug
@@ -46,6 +50,7 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
+          echo "3739c845f86906eed4b8e1c321a240a756e2eb5140537cddc796a85e36dc71d9  openssl3.zip" | shasum -a 256 -c
           mkdir C:/openssl-3
           unzip -d C:/openssl-3 openssl3.zip
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,7 +83,7 @@ jobs:
       - name: 'Get Github Action IP'
         if: always()
         id: ip
-        uses: haythem/public-ip@v1.3
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> $GITHUB_OUTPUT
         
       - name: 'Remove Github Action IP'
         if: always()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,27 +42,27 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install libcurl4 && sudo apt-get install libcurl4-openssl-dev
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             aws_sdk
           key: ${{ runner.os }}-aws-sdk-dynamic-lib
 
       - name: 'Set up JDK'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'corretto'
           java-version: 17
 
       - name: 'Configure AWS Credentials'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: 'Archive log results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: 'integration-test-logs-${{ matrix.engine_version }}'
           path: reports/tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ on:
       - 'ISSUE_TEMPLATE/**'
       - '**/remove-old-artifacts.yml'
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   BUILD_TYPE: Release
 
@@ -40,6 +44,7 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
+          echo "3739c845f86906eed4b8e1c321a240a756e2eb5140537cddc796a85e36dc71d9  openssl3.zip" | shasum -a 256 -c
           mkdir C:/openssl-3
           unzip -d C:/openssl-3 openssl3.zip
           cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
-          unzip -d C:/ openssl3.zip
+          mkdir C:/openssl-3.5.5
+          unzip -d C:/openssl-3.5.5 openssl3.zip
           cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
           cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
           unzip -d C:/ openssl3.zip
-          cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
           cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
           unzip -d C:/ openssl3.zip
           cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
-          cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
 
   build-mac:
     name: MacOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       CMAKE_GENERATOR: Unix Makefiles
       ODBC_DM_INCLUDES: /usr/local/include

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install OpenSSL 3
         run: |
-          curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.3.1.zip -o openssl3.zip
+          curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
           unzip -d C:/ openssl3.zip
           cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
           cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       MYSQL_DIR: C:/mysql-${{ vars.MYSQL_VERSION }}-winx64
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Configure build environment/dependencies
       - name: Install MySQL client libs
@@ -51,11 +51,11 @@ jobs:
           cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: always() && steps.cache-dynamic-aws-sdk.outputs.cache-hit != 'true'
         with:
           path: |
@@ -121,25 +121,25 @@ jobs:
       # Upload artifacts
       - name: Upload build artifacts - Binaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-sln
           path: ${{ github.workspace }}/build/MySQL_Connector_ODBC.sln
       - name: Upload build artifacts - Binaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-binaries
           path: ${{ github.workspace }}/build/bin/
       - name: Upload build artifacts - Libraries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-community-libraries
           path: ${{ github.workspace }}/build/lib/
       - name: Upload community test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-community-results
           path: ${{ github.workspace }}/build/test/Testing/Temporary/LastTest.log
@@ -152,7 +152,7 @@ jobs:
       ODBC_DM_INCLUDES: /usr/local/include
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Configure build environment/dependencies
       # Removing some /usr/local/bin files to avoid symlink issues wih brew update
@@ -190,7 +190,7 @@ jobs:
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: always() && steps.cache-dynamic-aws-sdk.outputs.cache-hit != 'true'
         with:
           path: |
@@ -258,19 +258,19 @@ jobs:
       # Upload artifacts
       - name: Upload build artifacts - Binaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-community-binaries
           path: ${{ github.workspace }}/build/bin/
       - name: Upload build artifacts - Libraries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-libraries
           path: ${{ github.workspace }}/build/lib/
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-community-results
           path: ${{ github.workspace }}/build/test/Testing/Temporary/LastTest.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
-          mkdir C:/openssl-3.5.5
-          unzip -d C:/openssl-3.5.5 openssl3.zip
-          cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
-          cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
+          mkdir C:/openssl-3
+          unzip -d C:/openssl-3 openssl3.zip
+          cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             aws_sdk
@@ -40,13 +40,13 @@ jobs:
           ./build_aws_sdk_unix.sh $BUILD_TYPE
 
       - name: 'Set up JDK'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'corretto'
           java-version: 17
 
       - name: 'Configure AWS Credentials'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -65,7 +65,7 @@ jobs:
       - name: 'Get Github Action IP'
         if: always()
         id: ip
-        uses: haythem/public-ip@v1.3
+        uses: haythem/public-ip@bdddd92c198b0955f0b494a8ebeac529754262ff # v1.3
         
       - name: 'Remove Github Action IP'
         if: always()
@@ -99,7 +99,7 @@ jobs:
 
       - name: 'Archive log results'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: 'performance-test-logs'
           path: reports/tests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,8 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
-          unzip -d C:/ openssl3.zip
+          mkdir C:/openssl-3.5.5
+          unzip -d C:/openssl-3.5.5 openssl3.zip
           cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
           cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,7 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
+          echo "3739c845f86906eed4b8e1c321a240a756e2eb5140537cddc796a85e36dc71d9  openssl3.zip" | shasum -a 256 -c
           mkdir C:/openssl-3
           unzip -d C:/openssl-3 openssl3.zip
           cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,10 +227,10 @@ jobs:
       - name: Install OpenSSL 3
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
-          mkdir C:/openssl-3.5.5
-          unzip -d C:/openssl-3.5.5 openssl3.zip
-          cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
-          cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
+          mkdir C:/openssl-3
+          unzip -d C:/openssl-3 openssl3.zip
+          cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       ODBC_DM_INCLUDES: /usr/local/include
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Configure build environment/dependencies
       # Removing some /usr/local/bin files to avoid symlink issues wih brew update
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload macOS installer as artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: installers-mac
           path: ${{ github.workspace }}/build/aws-mysql-odbc-*.pkg
@@ -97,7 +97,7 @@ jobs:
       CXX: g++-11
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Configure build environment/dependencies
       - name: Install build dependencies
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload Linux installer as artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: installers-linux
           path: ${{ github.workspace }}/build/aws-mysql-odbc-*.tar.gz
@@ -161,7 +161,7 @@ jobs:
       CMAKE_GENERATOR: Unix Makefiles
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Print OS version
         run: cat /etc/os-release
       - name: Print default working directory
@@ -202,7 +202,7 @@ jobs:
         run: cpack .
       - name: Upload AL2023 installer as artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: installers-al2023
           path: ${{ github.workspace }}/build/aws-mysql-odbc-*.tar.gz
@@ -216,7 +216,7 @@ jobs:
       WIX_DIR: "C:/Program Files (x86)/WiX Toolset v3.14/bin"
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Configure build environment/dependencies
       - name: Install MySQL client libs
@@ -234,7 +234,7 @@ jobs:
           cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
       - name: Build and install AWS SDK C++
         working-directory: ./scripts
@@ -242,14 +242,14 @@ jobs:
           .\build_aws_sdk_win.ps1 x64 ${{ env.BUILD_TYPE}} ON "${{env.CMAKE_GENERATOR}}"
 
       - name: Setup nmake
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
 
       - name: Run build installer script
         run: |
           .\build_installer.ps1 x64 ${{ env.BUILD_TYPE}} "${{env.CMAKE_GENERATOR}}" C:/mysql-${{ vars.MYSQL_VERSION }}-winx64 "${{env.WIX_DIR}}" C:/openssl-3/x64/include/
 
       - name: Configure AWS credentials OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-skip-session-tagging: true
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
@@ -257,7 +257,7 @@ jobs:
           role-session-name: mysql-win-signer
 
       - name: Configure AWS credentials Signer
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-skip-session-tagging: true
           role-chaining: true
@@ -275,7 +275,7 @@ jobs:
       
       - name: Upload Windows installer as artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: installers-windows
           path: ${{ github.workspace }}/wix/*.msi
@@ -287,9 +287,9 @@ jobs:
     needs: [build-mac, build-linux, build-windows]
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download all installers
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: installers
           pattern: installers-*
@@ -306,7 +306,7 @@ jobs:
           touch RELEASE_DETAILS.md
           echo "$RELEASE_DETAILS" > RELEASE_DETAILS.md
       - name: Upload to Draft Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           draft: true
           name: "AWS ODBC Driver for MySQL - v${{ env.RELEASE_VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build-mac:
     name: macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       CMAKE_GENERATOR: Unix Makefiles
       ODBC_DM_INCLUDES: /usr/local/include

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Install OpenSSL 3
         run: |
-          curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.3.1.zip -o openssl3.zip
+          curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
           unzip -d C:/ openssl3.zip
           cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
           cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,8 @@ jobs:
         run: |
           curl -L https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.5.zip -o openssl3.zip
           unzip -d C:/ openssl3.zip
-          cp -r C:/openssl-3/x64/bin/libssl-3-x64.dll C:/Windows/System32/
-          cp -r C:/openssl-3/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3.5.5/x64/bin/libssl-3-x64.dll C:/Windows/System32/
+          cp -r C:/openssl-3.5.5/x64/bin/libcrypto-3-x64.dll C:/Windows/System32/
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Remove Old Artifacts
-      uses: c-hive/gha-remove-artifacts@v1
+      uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b # v1
       with:
         age: '1 week'
         skip-tags: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,9 @@
 
 ##########################################################################
 
-PROJECT(MySQL_Connector_ODBC)
-
 CMAKE_MINIMUM_REQUIRED(VERSION 3.5...3.31 FATAL_ERROR)
+
+PROJECT(MySQL_Connector_ODBC)
 
 if(COMMAND cmake_policy)
   cmake_policy(VERSION 3.5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,10 @@
 
 PROJECT(MySQL_Connector_ODBC)
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.2 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5...3.31 FATAL_ERROR)
 
 if(COMMAND cmake_policy)
-  cmake_policy(VERSION 3.0)
+  cmake_policy(VERSION 3.5)
   cmake_policy(SET CMP0054 NEW)
   cmake_policy(SET CMP0003 NEW)
   cmake_policy(SET CMP0022 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ include(FetchContent)
 FetchContent_Declare(
   ctpl
   URL https://github.com/vit-vit/CTPL/archive/refs/tags/ctpl_v.0.0.2.zip
+  URL_HASH SHA256=040565426fd24665c67402b1b93cb8f18e2275369637fc84e0601c7b31085cbb
 )
 
 FetchContent_MakeAvailable(ctpl)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -321,7 +321,7 @@ WHILE(${DRIVER_INDEX} LESS ${DRIVERS_COUNT})
 
   FetchContent_Declare(
           json
-          URL https://github.com/nlohmann/json/releases/download/v3.10.5/json.tar.xz
+          URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
   )
 
   FetchContent_Declare(

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -322,11 +322,13 @@ WHILE(${DRIVER_INDEX} LESS ${DRIVERS_COUNT})
   FetchContent_Declare(
           json
           URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+          URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa
   )
 
   FetchContent_Declare(
           httplib
           URL https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.16.1.zip
+          URL_HASH SHA256=81df7d70c7e56c0010650d7f6d0a6471bb59b17a5d7db339c7d82f39e3988640
   )
 
   set(CMAKE_POLICY_VERSION_MINIMUM 3.5)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -329,6 +329,7 @@ WHILE(${DRIVER_INDEX} LESS ${DRIVERS_COUNT})
           URL https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.16.1.zip
   )
 
+  set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
   FetchContent_MakeAvailable(httplib json)
 
   TARGET_INCLUDE_DIRECTORIES(${DRIVER_NAME} PUBLIC "${httplib_SOURCE_DIR}" ${OPENSSL_INCLUDE_DIR})

--- a/integration/CMakeLists.txt
+++ b/integration/CMakeLists.txt
@@ -49,6 +49,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
+  URL_HASH SHA256=ffa17fbc5953900994e2deec164bb8949879ea09b411e07f215bfbb1f87f4632
 )
 FetchContent_Declare(
   toxiproxy

--- a/unit_testing/CMakeLists.txt
+++ b/unit_testing/CMakeLists.txt
@@ -36,7 +36,7 @@ set(CMAKE_CXX_STANDARD 14)
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+  URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
 )
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/unit_testing/CMakeLists.txt
+++ b/unit_testing/CMakeLists.txt
@@ -37,6 +37,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
+  URL_HASH SHA256=f179ec217f9b3b3f3c6e8b02d3e7eda997b49e4ce26d6b235c9053bec9c0bf9f
 )
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/unit_testing/failover_reader_handler_test.cc
+++ b/unit_testing/failover_reader_handler_test.cc
@@ -299,8 +299,8 @@ TEST_F(FailoverReaderHandlerTest, GetConnectionFromHosts_FastestHost) {
 
     // May not have actually connected during failover
     // Cannot delete at the end as it may cause double delete
+    mock_reader_b_proxy->release_ds();
     Mock::AllowLeak(mock_reader_b_proxy);
-    Mock::AllowLeak(mock_reader_b_proxy->get_ds());
 
     EXPECT_CALL(*mock_ts, get_topology(_, true)).WillRepeatedly(Return(topology));
 
@@ -390,8 +390,8 @@ TEST_F(FailoverReaderHandlerTest, Failover_Success_Reader) {
 
     // May not have actually connected during failover
     // Cannot delete at the end as it may cause double delete
+    mock_reader_b_proxy->release_ds();
     Mock::AllowLeak(mock_reader_b_proxy);
-    Mock::AllowLeak(mock_reader_b_proxy->get_ds());
 
     auto current_topology = std::make_shared<CLUSTER_TOPOLOGY_INFO>();
     current_topology->add_host(writer_host);

--- a/unit_testing/failover_writer_handler_test.cc
+++ b/unit_testing/failover_writer_handler_test.cc
@@ -65,10 +65,10 @@ class FailoverWriterHandlerTest : public testing::Test {
     std::shared_ptr<MOCK_TOPOLOGY_SERVICE> mock_ts;
     std::shared_ptr<MOCK_READER_HANDLER> mock_reader_handler;
     std::shared_ptr<MOCK_CONNECTION_HANDLER> mock_connection_handler;
-    MOCK_CONNECTION_PROXY* mock_reader_a_proxy;
-    MOCK_CONNECTION_PROXY* mock_reader_b_proxy;
-    MOCK_CONNECTION_PROXY* mock_writer_proxy;
-    MOCK_CONNECTION_PROXY* mock_new_writer_proxy;
+    MOCK_CONNECTION_PROXY* mock_reader_a_proxy = nullptr;
+    MOCK_CONNECTION_PROXY* mock_reader_b_proxy = nullptr;
+    MOCK_CONNECTION_PROXY* mock_writer_proxy = nullptr;
+    MOCK_CONNECTION_PROXY* mock_new_writer_proxy = nullptr;
     ctpl::thread_pool failover_thread_pool;
 
     static void SetUpTestSuite() {}
@@ -103,6 +103,7 @@ class FailoverWriterHandlerTest : public testing::Test {
     }
 
     void TearDown() override {
+        failover_thread_pool.stop(true);
         cleanup_odbc_handles(env, dbc, ds);
     }
 };
@@ -156,9 +157,6 @@ TEST_F(FailoverWriterHandlerTest, ReconnectToWriter_SlowReaderA) {
     mock_writer_proxy = new MOCK_CONNECTION_PROXY(dbc, ds);
     mock_reader_a_proxy = new MOCK_CONNECTION_PROXY(dbc, ds);
 
-    // May not have actually connected during failover
-    // Cannot delete at the end as it may cause double delete
-    mock_reader_b_proxy->release_ds();
     Mock::AllowLeak(mock_reader_a_proxy);
     
     const auto new_topology = std::make_shared<CLUSTER_TOPOLOGY_INFO>();
@@ -263,9 +261,6 @@ TEST_F(FailoverWriterHandlerTest, ConnectToReaderA_SlowWriter) {
     mock_new_writer_proxy = new MOCK_CONNECTION_PROXY(dbc, ds);
     mock_reader_a_proxy = new MOCK_CONNECTION_PROXY(dbc, ds);
 
-    // May not have actually connected during failover
-    // Cannot delete at the end as it may cause double delete
-    mock_reader_b_proxy->release_ds();
     Mock::AllowLeak(mock_writer_proxy);
     
     const auto new_topology = std::make_shared<CLUSTER_TOPOLOGY_INFO>();

--- a/unit_testing/failover_writer_handler_test.cc
+++ b/unit_testing/failover_writer_handler_test.cc
@@ -158,9 +158,9 @@ TEST_F(FailoverWriterHandlerTest, ReconnectToWriter_SlowReaderA) {
 
     // May not have actually connected during failover
     // Cannot delete at the end as it may cause double delete
+    mock_reader_b_proxy->release_ds();
     Mock::AllowLeak(mock_reader_a_proxy);
-    Mock::AllowLeak(mock_reader_a_proxy->get_ds());
-
+    
     const auto new_topology = std::make_shared<CLUSTER_TOPOLOGY_INFO>();
     new_topology->add_host(new_writer_host);
     new_topology->add_host(reader_a_host);
@@ -265,9 +265,9 @@ TEST_F(FailoverWriterHandlerTest, ConnectToReaderA_SlowWriter) {
 
     // May not have actually connected during failover
     // Cannot delete at the end as it may cause double delete
+    mock_reader_b_proxy->release_ds();
     Mock::AllowLeak(mock_writer_proxy);
-    Mock::AllowLeak(mock_writer_proxy->get_ds());
-
+    
     const auto new_topology = std::make_shared<CLUSTER_TOPOLOGY_INFO>();
     new_topology->add_host(new_writer_host);
     new_topology->add_host(reader_a_host);

--- a/unit_testing/main.cc
+++ b/unit_testing/main.cc
@@ -29,6 +29,12 @@
  
 #include "gtest/gtest.h"
 
+#ifdef WIN32
+#ifndef _UNIX_
+extern void myodbc_end();
+#endif
+#endif
+
 int main(int argc, char** argv) {
 #ifdef WIN32
 #ifdef _DEBUG
@@ -52,6 +58,11 @@ int main(int argc, char** argv) {
 #ifdef __APPLE__
   // Disable malloc logging
   system("unset MallocStackLogging");
+#endif
+#ifdef WIN32
+#ifndef _UNIX_
+  myodbc_end();
+#endif
 #endif
   return failures;
 }

--- a/unit_testing/mock_objects.h
+++ b/unit_testing/mock_objects.h
@@ -69,6 +69,11 @@ public:
         return this->ds;
     };
 
+    void release_ds() {
+        delete this->ds;
+        this->ds = nullptr;
+    };
+    
     MOCK_METHOD(bool, is_connected, ());
     MOCK_METHOD(std::string, get_host, ());
     MOCK_METHOD(unsigned int, get_port, ());


### PR DESCRIPTION
This fixes CVE-2024-6119

### Summary

CVE-2024-6119 exists due to openssl

### Description

<!--- Description of the ticket. e.g., What is the ticket accomplishing, why is it important, what areas of the code does it affect, etc. -->

### Review Status

<!-- Place an "x" in the brackets of all options that apply. e.g., - [x] This is complete -->
- [X] This is ready for review
- [X] This is complete

### Additional Reviewers

<!-- Tag reviewers needed for this PR. -->
