### PR TITLE
fix: correct comparison bug, missing break, and error diagnostics

### DIFF
--- a/driver/connect.cc
+++ b/driver/connect.cc
@@ -1065,7 +1065,7 @@ SQLRETURN DBC::connect(DataSource *dsrc, bool failover_enabled, bool is_monitor_
     }
     else if (autocommit_is_on() && connection_proxy->autocommit(FALSE))
     {
-      /** @todo set error */
+      set_error("HY000", "Failed to disable autocommit", 0);
       return SQL_ERROR;
     }
   }
@@ -1074,7 +1074,7 @@ SQLRETURN DBC::connect(DataSource *dsrc, bool failover_enabled, bool is_monitor_
   {
     if (connection_proxy->autocommit(TRUE))
     {
-      /** @todo set error */
+      set_error("HY000", "Failed to enable autocommit", 0);
       return SQL_ERROR;
     }
   }

--- a/driver/options.cc
+++ b/driver/options.cc
@@ -237,6 +237,7 @@ get_constmt_attr(SQLSMALLINT  HandleType,
         case SQL_ATTR_FETCH_BOOKMARK_PTR:
           *((void **) ValuePtr) = options->bookmark_ptr;
           *StringLengthPtr= sizeof(SQLPOINTER);
+          break;
 
         case 1226:/* MS SQL Server Extension */
         case 1227:

--- a/driver/results.cc
+++ b/driver/results.cc
@@ -685,7 +685,7 @@ sql_get_data(STMT *stmt, SQLSMALLINT fCType, uint column_number,
     case SQL_C_INTERVAL_HOUR_TO_SECOND:
     case SQL_C_INTERVAL_HOUR_TO_MINUTE:
       {
-        if (field->type= MYSQL_TYPE_TIME)
+        if (field->type == MYSQL_TYPE_TIME)
         {
           SQL_TIME_STRUCT ts;
           char *tmp= get_string(stmt,


### PR DESCRIPTION
### Summary

This PR addresses three localized code quality issues in the core driver implementation, including a critical assignment-versus-comparison bug that corrupted field metadata during result retrieval.

### Description

This PR fixes three distinct issues identified in the driver codebase to improve stability and diagnosability:

1. **Assignment vs. Comparison Fix (`results.cc:688`)**: Fixed a critical bug where `field->type = MYSQL_TYPE_TIME` was using an assignment operator instead of a comparison operator (`==`). This previously caused the `if` statement to always evaluate as true (since `MYSQL_TYPE_TIME` is non-zero), improperly overwriting the field's metadata type and making the intended error-handling `else` branch entirely unreachable. Any non-TIME columns being converted to interval types would silently produce invalid data instead of properly throwing `MYERR_07006`.

2. **Missing `break` Statement (`options.cc:240`)**: Added a missing `break;` statement at the end of the `SQL_ATTR_FETCH_BOOKMARK_PTR` case block. While currently benign (as it only fell through to an empty `default` case that contained a break), this latent defect would have caused unintended fall-through behavior if the `default` case was ever modified.

3. **Missing Error Diagnostics (`connect.cc:1068, 1077`)**: Replaced two placeholder `/** @todo set error */` comments with actual `set_error()` calls during autocommit configuration failures. Previously, if enabling or disabling autocommit failed, the driver would return `SQL_ERROR` but `SQLGetDiagRec()` would return no useful diagnostic information for the application developer.

### Review Status

- [x] This is ready for review
- [ ] This is complete

@renish-patel thank you for testing

### Additional Reviewers
@karenc-bq tagged for reviewing 

<!-- Tag reviewers needed for this PR. -->
